### PR TITLE
Add `MongodStarter` as argument in `EmbeddedMongo.start`

### DIFF
--- a/embedded/src/main/scala/mongo4cats/embedded/EmbeddedMongo.scala
+++ b/embedded/src/main/scala/mongo4cats/embedded/EmbeddedMongo.scala
@@ -28,9 +28,11 @@ import scala.concurrent.duration._
 
 object EmbeddedMongo {
 
+  private lazy val defaultStarter: MongodStarter = MongodStarter.getDefaultInstance
+
   def start[F[_]](
       config: MongodConfig,
-      starter: MongodStarter = MongodStarter.getDefaultInstance,
+      starter: MongodStarter = defaultStarter,
       maxAttempts: Int = 10,
       attempt: Int = 0,
       lastError: Option[Throwable] = None


### PR DESCRIPTION
Just a small change to make `EmbeddedMongo.start` more flexible.