### PR TITLE
[WIP] Add generic derivation to org.bson.BsonValue

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        scala: [2.12.15, 2.13.8, 3.1.1]
+        scala: [2.12.16, 2.13.8, 3.1.1]
         java: [temurin@18]
     runs-on: ${{ matrix.os }}
     steps:

--- a/bson-derivation/src/main/scala-2.12/mongo4cats/derivation/bson/ScalaVersionDependentBsonDecoders.scala
+++ b/bson-derivation/src/main/scala-2.12/mongo4cats/derivation/bson/ScalaVersionDependentBsonDecoders.scala
@@ -14,8 +14,21 @@
  * limitations under the License.
  */
 
-package mongo4cats
+package mongo4cats.derivation.bson
 
-import scala.collection.convert.AsJavaConverters
+import cats.syntax.all._
+import mongo4cats.derivation.bson.BsonDecoder.instance
+import org.bson.BsonArray
 
-trait AsJava extends AsJavaConverters
+import scala.jdk.CollectionConverters._
+import scala.collection.generic.CanBuildFrom
+
+trait ScalaVersionDependentBsonDecoders {
+
+  implicit def iterableBsonDecoder[L[_], A](implicit decA: BsonDecoder[A], cbf: CanBuildFrom[Nothing, A, L[A]]): BsonDecoder[L[A]] =
+    instance {
+      case vs: BsonArray => vs.getValues.asScala.toList.traverse(decA(_)).map(_.to[L])
+      case other         => new Throwable(s"Not a Iterable: ${other}").asLeft
+    }
+
+}

--- a/bson-derivation/src/main/scala-2.12/mongo4cats/derivation/bson/ScalaVersionDependentBsonEncoders.scala
+++ b/bson-derivation/src/main/scala-2.12/mongo4cats/derivation/bson/ScalaVersionDependentBsonEncoders.scala
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2020 Kirill5k
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package mongo4cats.derivation.bson
+
+import mongo4cats.derivation.bson.BsonEncoder.instance
+import org.bson.BsonValue
+import org.bson.BsonArray
+
+import scala.collection.Iterable
+
+trait ScalaVersionDependentBsonEncoders {
+
+  implicit final def encodeIterable[L[_] <: Iterable[_], A](implicit encA: BsonEncoder[A]): BsonEncoder[L[A]] =
+    instance {
+      case asIt: Iterable[A] @unchecked =>
+        val arrayList = new java.util.ArrayList[BsonValue]()
+        asIt.foreach(a => arrayList.add(encA(a)))
+        new BsonArray(arrayList)
+      case _ => throw new Throwable("Not an Iterable")
+    }
+}

--- a/bson-derivation/src/main/scala-2.13/mongo4cats/derivation/bson/ScalaVersionDependentBsonEncoders.scala
+++ b/bson-derivation/src/main/scala-2.13/mongo4cats/derivation/bson/ScalaVersionDependentBsonEncoders.scala
@@ -14,8 +14,19 @@
  * limitations under the License.
  */
 
-package mongo4cats
+package mongo4cats.derivation.bson
 
-import scala.collection.convert.AsJavaConverters
+import mongo4cats.derivation.bson.BsonEncoder.instance
+import org.bson.{BsonArray, BsonValue}
 
-trait AsJava extends AsJavaConverters
+trait ScalaVersionDependentBsonEncoders {
+
+  implicit final def encodeIterable[L[_] <: Iterable[_], A](implicit encA: BsonEncoder[A]): BsonEncoder[L[A]] =
+    instance {
+      case asIt: Iterable[A] @unchecked =>
+        val arrayList = new java.util.ArrayList[BsonValue](Math.max(0, asIt.knownSize))
+        asIt.foreach(a => arrayList.add(encA(a)))
+        new BsonArray(arrayList)
+      case _ => throw new Throwable("Not an Iterable")
+    }
+}

--- a/bson-derivation/src/main/scala-2/mongo4cats/derivation/bson/MagnoliaBsonDecoder.scala
+++ b/bson-derivation/src/main/scala-2/mongo4cats/derivation/bson/MagnoliaBsonDecoder.scala
@@ -1,0 +1,179 @@
+/*
+ * Copyright 2020 Kirill5k
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package mongo4cats.derivation.bson
+
+import cats.syntax.all._
+import magnolia1._
+import mongo4cats.derivation.bson.BsonDecoder.Result
+import mongo4cats.derivation.bson.configured.Configuration
+import org.bson.{BsonDocument, BsonValue}
+
+private[bson] object MagnoliaBsonDecoder {
+
+  private[bson] def join[T](
+      caseClass: CaseClass[BsonDecoder, T]
+  )(implicit configuration: Configuration): BsonDecoder[T] = {
+    val paramJsonKeyLookup: Map[String, String] =
+      caseClass.parameters.map { p =>
+        val jsonKeyAnnotation = p.annotations.collectFirst { case ann: BsonKey => ann }
+
+        jsonKeyAnnotation match {
+          case Some(ann) => p.label -> ann.value
+          case None      => p.label -> configuration.transformMemberNames(p.label)
+        }
+      }.toMap
+
+    // println(paramJsonKeyLookup)
+
+    if (paramJsonKeyLookup.values.toList.distinct.length != caseClass.parameters.length) {
+      throw new BsonDerivationError("Duplicate key detected after applying transformation function for case class parameters")
+    }
+
+    if (configuration.useDefaults) {
+      new BsonDecoder[T] {
+        override def apply(bson: BsonValue): Result[T] =
+          caseClass
+            .constructEither { p =>
+              val key: String = paramJsonKeyLookup.getOrElse(
+                p.label,
+                throw new IllegalStateException("Looking up a parameter label should always yield a value. This is a bug")
+              )
+
+              bson match {
+                case doc: BsonDocument =>
+                  val value: BsonValue = doc.get(key)
+
+                  if (value == null || value.isNull) {
+                    p.default.fold(
+                      // Some decoders (in particular, the default Option[T] decoder) do special things when a key is missing,
+                      // so we give them a chance to do their thing here.
+                      p.typeclass.apply(value)
+                    )(x => x.asRight)
+                  } else {
+                    p.typeclass.apply(value)
+                  }
+
+                case other => new Throwable(s"Not a BsonDocument: ${other}").asLeft
+              }
+            }
+            .leftMap(_.head)
+      }
+    } else {
+      new BsonDecoder[T] {
+        override def apply(bsonValue: BsonValue): Result[T] =
+          bsonValue match {
+            case doc: BsonDocument =>
+              caseClass
+                .constructEither(p =>
+                  p.typeclass
+                    .apply(
+                      doc
+                        .get(
+                          paramJsonKeyLookup.getOrElse(
+                            p.label,
+                            throw new IllegalStateException("Looking up a parameter label should always yield a value. This is a bug")
+                          )
+                        )
+                    )
+                )
+                .leftMap(_.head)
+            case other => throw new IllegalStateException(s"""|Not BsonDocument: $other
+                 |Type: ${caseClass.typeName.full}""".stripMargin)
+          }
+      }
+    }
+  }
+
+  private[bson] def split[T](
+      sealedTrait: SealedTrait[BsonDecoder, T]
+  )(implicit configuration: Configuration): BsonDecoder[T] = {
+    val constructorLookup: Map[String, Subtype[BsonDecoder, T]] =
+      sealedTrait.subtypes.map(s => configuration.transformConstructorNames(s.typeName.short) -> s).toMap
+
+    if (constructorLookup.size != sealedTrait.subtypes.length) {
+      throw new BsonDerivationError("Duplicate key detected after applying transformation function for case class parameters")
+    }
+
+    configuration.discriminator match {
+      case Some(discriminator) => new DiscriminatedDecoder[T](discriminator, constructorLookup)
+      case None                => new NonDiscriminatedDecoder[T](constructorLookup)
+    }
+  }
+
+  private[bson] class NonDiscriminatedDecoder[T](constructorLookup: Map[String, Subtype[BsonDecoder, T]]) extends BsonDecoder[T] {
+
+    private val knownSubTypes: String = constructorLookup.keys.toSeq.sorted.mkString(",")
+
+    override def apply(bson: BsonValue): Result[T] =
+      bson match {
+        case doc: BsonDocument if doc.keySet().size === 1 =>
+          val key: String = doc.getFirstKey
+
+          for {
+            theSubtype <- Either.fromOption(
+              constructorLookup.get(key),
+              new Throwable(
+                s"""|Can't decode coproduct type: couldn't find matching subtype.
+                      |JSON: ${bson},
+                      |Key: $key
+                      |
+                      |Known subtypes: $knownSubTypes\n""".stripMargin
+              )
+            )
+
+            result <- theSubtype.typeclass(doc.get(key))
+          } yield result
+
+        case _ =>
+          Left(
+            new Throwable(
+              s"""|Can't decode coproduct type: zero or several keys were found, while coproduct type requires exactly one.
+                    |JSON: ${bson},
+                    |Keys: $${c.keys.map(_.mkString(","))}
+                    |Known subtypes: $knownSubTypes\n""".stripMargin
+            )
+          )
+      }
+  }
+
+  private[bson] class DiscriminatedDecoder[T](discriminator: String, constructorLookup: Map[String, Subtype[BsonDecoder, T]])
+      extends BsonDecoder[T] {
+
+    val knownSubTypes: String = constructorLookup.keys.toSeq.sorted.mkString(",")
+
+    override def apply(bson: BsonValue): Result[T] =
+      bson match {
+        case doc: BsonDocument =>
+          Either.catchNonFatal(doc.getString(discriminator)) match {
+            case Left(_) =>
+              Left(new Throwable(s"""|Can't decode coproduct type: couldn't find discriminator or is not of type String.
+                      |discriminator key: discriminator""".stripMargin))
+
+            case Right(ctorName) =>
+              constructorLookup.get(ctorName.toString) match {
+                case Some(subType) => subType.typeclass.apply(doc)
+                case None =>
+                  Left(new Throwable(s"""|Can't decode coproduct type: constructor name not found in known constructor names
+                          |BSON: ${doc}
+                          |Allowed discriminators: $knownSubTypes""".stripMargin))
+              }
+          }
+
+        case _ => Left(new Throwable("Not a BsonDocument"))
+      }
+  }
+}

--- a/bson-derivation/src/main/scala-2/mongo4cats/derivation/bson/MagnoliaBsonEncoder.scala
+++ b/bson-derivation/src/main/scala-2/mongo4cats/derivation/bson/MagnoliaBsonEncoder.scala
@@ -1,0 +1,95 @@
+/*
+ * Copyright 2020 Kirill5k
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package mongo4cats.derivation.bson
+
+import magnolia1._
+import mongo4cats.derivation.bson.configured.Configuration
+import org.bson.{BsonDocument, BsonValue}
+
+private[bson] object MagnoliaBsonEncoder {
+
+  private[bson] def join[T](caseClass: CaseClass[BsonEncoder, T])(implicit config: Configuration): BsonEncoder[T] = {
+    val paramJsonKeyLookup =
+      caseClass.parameters.map { p =>
+        val jsonKeyAnnotation = p.annotations.collectFirst { case ann: BsonKey => ann }
+
+        jsonKeyAnnotation match {
+          case Some(ann) => p.label -> ann.value
+          case None      => p.label -> config.transformMemberNames(p.label)
+        }
+      }.toMap
+
+    if (paramJsonKeyLookup.values.toList.distinct.size != caseClass.parameters.length) {
+      throw new BsonDerivationError(
+        "Duplicate key detected after applying transformation function for case class parameters"
+      )
+    }
+
+    new BsonEncoder[T] {
+      def apply(a: T): BsonValue = {
+        val bsonDoc = new BsonDocument(caseClass.parameters.size)
+
+        caseClass.parameters
+          .map { p =>
+            val label = paramJsonKeyLookup.getOrElse(
+              p.label,
+              throw new IllegalStateException("Looking up a parameter label should always yield a value. This is a bug")
+            )
+            label -> p.typeclass(p.dereference(a))
+          }
+          .foreach { case (k, v) => bsonDoc.append(k, v) }
+
+        bsonDoc
+      }
+    }
+  }
+
+  private[bson] def split[T](
+      sealedTrait: SealedTrait[BsonEncoder, T]
+  )(implicit config: Configuration): BsonEncoder[T] = {
+    {
+      val origTypeNames = sealedTrait.subtypes.map(_.typeName.short)
+      val transformed   = origTypeNames.map(config.transformConstructorNames).distinct
+      if (transformed.length != origTypeNames.length) {
+        throw new BsonDerivationError(
+          "Duplicate key detected after applying transformation function for " +
+            "sealed trait child classes"
+        )
+      }
+    }
+
+    new BsonEncoder[T] {
+      def apply(a: T): BsonValue =
+        sealedTrait.split(a) { subtype =>
+          val baseJson = subtype.typeclass(subtype.cast(a))
+          val constructorName = config
+            .transformConstructorNames(subtype.typeName.short)
+          config.discriminator match {
+            case Some(discriminator) =>
+              // Note: Here we handle the edge case where a subtype of a sealed trait has a custom encoder which does not encode
+              // encode into a JSON object and thus we cannot insert the discriminator key. In this case we fallback
+              // to the non-discriminator case for this subtype. This is same as the behavior of circe-generic-extras
+              baseJson match {
+                case bsonDoc: BsonDocument => bsonDoc.clone().append(discriminator, org.bson.Document.parse(constructorName).toBsonDocument)
+                case _                     => new BsonDocument(constructorName, baseJson)
+              }
+            case None => new BsonDocument(constructorName, baseJson)
+          }
+        }
+    }
+  }
+}

--- a/bson-derivation/src/main/scala-2/mongo4cats/derivation/bson/configured/decoder/auto.scala
+++ b/bson-derivation/src/main/scala-2/mongo4cats/derivation/bson/configured/decoder/auto.scala
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2020 Kirill5k
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package mongo4cats.derivation.bson.configured.decoder
+
+import mongo4cats.derivation.bson.{BsonDecoder, MagnoliaBsonDecoder}
+import mongo4cats.derivation.bson.configured.Configuration
+import magnolia1.{CaseClass, Magnolia, SealedTrait}
+
+object auto {
+
+  type Typeclass[T] = BsonDecoder[T]
+
+  def join[T](caseClass: CaseClass[Typeclass, T])(implicit configuration: Configuration): Typeclass[T] =
+    MagnoliaBsonDecoder.join(caseClass)
+
+  def split[T](sealedTrait: SealedTrait[Typeclass, T])(implicit configuration: Configuration): Typeclass[T] =
+    MagnoliaBsonDecoder.split(sealedTrait)
+
+  implicit def magnoliaConfiguredDecoder[T]: Typeclass[T] = macro Magnolia.gen[T]
+}

--- a/bson-derivation/src/main/scala-2/mongo4cats/derivation/bson/configured/decoder/semiauto.scala
+++ b/bson-derivation/src/main/scala-2/mongo4cats/derivation/bson/configured/decoder/semiauto.scala
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2020 Kirill5k
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package mongo4cats.derivation.bson.configured.decoder
+
+import mongo4cats.derivation.bson.{BsonDecoder, MagnoliaBsonDecoder}
+import mongo4cats.derivation.bson.configured.Configuration
+import magnolia1.{CaseClass, Magnolia, SealedTrait}
+
+object semiauto {
+
+  type Typeclass[T] = BsonDecoder[T]
+
+  def join[T](caseClass: CaseClass[Typeclass, T])(implicit configuration: Configuration): Typeclass[T] =
+    MagnoliaBsonDecoder.join(caseClass)
+
+  def split[T](sealedTrait: SealedTrait[Typeclass, T])(implicit configuration: Configuration): Typeclass[T] =
+    MagnoliaBsonDecoder.split(sealedTrait)
+
+  def magnoliaConfiguredDecoder[T]: Typeclass[T] = macro Magnolia.gen[T]
+}

--- a/bson-derivation/src/main/scala-2/mongo4cats/derivation/bson/configured/encoder/auto.scala
+++ b/bson-derivation/src/main/scala-2/mongo4cats/derivation/bson/configured/encoder/auto.scala
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2020 Kirill5k
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package mongo4cats.derivation.bson.configured.encoder
+
+import mongo4cats.derivation.bson.{BsonEncoder, MagnoliaBsonEncoder}
+import mongo4cats.derivation.bson.configured.Configuration
+import magnolia1.{CaseClass, Magnolia, SealedTrait}
+
+object auto {
+
+  type Typeclass[T] = BsonEncoder[T]
+
+  def join[T](caseClass: CaseClass[Typeclass, T])(implicit configuration: Configuration): Typeclass[T] =
+    MagnoliaBsonEncoder.join(caseClass)
+
+  def split[T](sealedTrait: SealedTrait[Typeclass, T])(implicit configuration: Configuration): Typeclass[T] =
+    MagnoliaBsonEncoder.split(sealedTrait)
+
+  implicit def magnoliaConfiguredEncoder[T]: Typeclass[T] = macro Magnolia.gen[T]
+}

--- a/bson-derivation/src/main/scala-2/mongo4cats/derivation/bson/configured/encoder/semiauto.scala
+++ b/bson-derivation/src/main/scala-2/mongo4cats/derivation/bson/configured/encoder/semiauto.scala
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2020 Kirill5k
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package mongo4cats.derivation.bson.configured.encoder
+
+import mongo4cats.derivation.bson.{BsonEncoder, MagnoliaBsonEncoder}
+import mongo4cats.derivation.bson.configured.Configuration
+import magnolia1.{CaseClass, Magnolia, SealedTrait}
+
+object semiauto {
+
+  type Typeclass[T] = BsonEncoder[T]
+
+  def join[T](caseClass: CaseClass[Typeclass, T])(implicit configuration: Configuration): Typeclass[T] =
+    MagnoliaBsonEncoder.join(caseClass)
+
+  def split[T](sealedTrait: SealedTrait[Typeclass, T])(implicit configuration: Configuration): Typeclass[T] =
+    MagnoliaBsonEncoder.split(sealedTrait)
+
+  def magnoliaConfiguredEncoder[T]: Typeclass[T] = macro Magnolia.gen[T]
+}

--- a/bson-derivation/src/main/scala-2/mongo4cats/derivation/bson/derivation/decoder/auto.scala
+++ b/bson-derivation/src/main/scala-2/mongo4cats/derivation/bson/derivation/decoder/auto.scala
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2020 Kirill5k
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package mongo4cats.derivation.bson.derivation.decoder
+
+import mongo4cats.derivation.bson.{BsonDecoder, MagnoliaBsonDecoder}
+import mongo4cats.derivation.bson.configured.Configuration
+import magnolia1.{CaseClass, Magnolia, SealedTrait}
+
+object auto {
+
+  type Typeclass[T] = BsonDecoder[T]
+
+  def join[T](caseClass: CaseClass[Typeclass, T]): Typeclass[T] =
+    MagnoliaBsonDecoder.join(caseClass)(Configuration.default)
+
+  def split[T](sealedTrait: SealedTrait[Typeclass, T]): Typeclass[T] =
+    MagnoliaBsonDecoder.split(sealedTrait)(Configuration.default)
+
+  implicit def magnoliaBsonDecoder[T]: Typeclass[T] = macro Magnolia.gen[T]
+}

--- a/bson-derivation/src/main/scala-2/mongo4cats/derivation/bson/derivation/decoder/semiauto.scala
+++ b/bson-derivation/src/main/scala-2/mongo4cats/derivation/bson/derivation/decoder/semiauto.scala
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2020 Kirill5k
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package mongo4cats.derivation.bson.derivation.decoder
+
+import mongo4cats.derivation.bson.{BsonDecoder, MagnoliaBsonDecoder}
+import mongo4cats.derivation.bson.configured.Configuration
+import magnolia1.{CaseClass, Magnolia, SealedTrait}
+
+object semiauto {
+
+  type Typeclass[T] = BsonDecoder[T]
+
+  def join[T](caseClass: CaseClass[Typeclass, T]): Typeclass[T] =
+    MagnoliaBsonDecoder.join(caseClass)(Configuration.default)
+
+  def split[T](sealedTrait: SealedTrait[Typeclass, T]): Typeclass[T] =
+    MagnoliaBsonDecoder.split(sealedTrait)(Configuration.default)
+
+  def magnoliaBsonDecoder[T]: Typeclass[T] = macro Magnolia.gen[T]
+}

--- a/bson-derivation/src/main/scala-2/mongo4cats/derivation/bson/derivation/encoder/auto.scala
+++ b/bson-derivation/src/main/scala-2/mongo4cats/derivation/bson/derivation/encoder/auto.scala
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2020 Kirill5k
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package mongo4cats.derivation.bson.derivation.encoder
+
+import mongo4cats.derivation.bson.{BsonEncoder, MagnoliaBsonEncoder}
+import mongo4cats.derivation.bson.configured.Configuration
+import magnolia1.{CaseClass, Magnolia, SealedTrait}
+
+object auto {
+
+  type Typeclass[T] = BsonEncoder[T]
+
+  def join[T](caseClass: CaseClass[Typeclass, T]): Typeclass[T] =
+    MagnoliaBsonEncoder.join(caseClass)(Configuration.default)
+
+  def split[T](sealedTrait: SealedTrait[Typeclass, T]): Typeclass[T] =
+    MagnoliaBsonEncoder.split(sealedTrait)(Configuration.default)
+
+  implicit def magnoliaBsonEncoder[T]: Typeclass[T] = macro Magnolia.gen[T]
+}

--- a/bson-derivation/src/main/scala-2/mongo4cats/derivation/bson/derivation/encoder/semiauto.scala
+++ b/bson-derivation/src/main/scala-2/mongo4cats/derivation/bson/derivation/encoder/semiauto.scala
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2020 Kirill5k
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package mongo4cats.derivation.bson.derivation.encoder
+
+import mongo4cats.derivation.bson.{BsonEncoder, MagnoliaBsonEncoder}
+import mongo4cats.derivation.bson.configured.Configuration
+import magnolia1.{CaseClass, Magnolia, SealedTrait}
+
+object semiauto {
+
+  type Typeclass[T] = BsonEncoder[T]
+
+  def join[T](caseClass: CaseClass[Typeclass, T]): Typeclass[T] =
+    MagnoliaBsonEncoder.join(caseClass)(Configuration.default)
+
+  def split[T](sealedTrait: SealedTrait[Typeclass, T]): Typeclass[T] =
+    MagnoliaBsonEncoder.split(sealedTrait)(Configuration.default)
+
+  def magnoliaBsonEncoder[T]: Typeclass[T] = macro Magnolia.gen[T]
+}

--- a/bson-derivation/src/main/scala-3/mongo4cats/derivation/bson/MagnoliaBsonDecoder.scala
+++ b/bson-derivation/src/main/scala-3/mongo4cats/derivation/bson/MagnoliaBsonDecoder.scala
@@ -1,0 +1,180 @@
+/*
+ * Copyright 2020 Kirill5k
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package mongo4cats.derivation.bson
+
+import cats.syntax.all._
+import magnolia1._
+import mongo4cats.derivation.bson.BsonDecoder.Result
+import mongo4cats.derivation.bson.configured.Configuration
+import org.bson.{BsonDocument, BsonValue}
+
+private[bson] object MagnoliaBsonDecoder {
+
+  private[bson] def join[T](
+      caseClass: CaseClass[BsonDecoder, T]
+  )(implicit configuration: Configuration): BsonDecoder[T] = {
+    val paramJsonKeyLookup: Map[String, String] =
+      caseClass.params.map { p =>
+        val jsonKeyAnnotation = p.annotations.collectFirst { case ann: BsonKey => ann }
+
+        jsonKeyAnnotation match {
+          case Some(ann) => p.label -> ann.value
+          case None      => p.label -> configuration.transformMemberNames(p.label)
+        }
+      }.toMap
+
+    // println(paramJsonKeyLookup)
+
+    if (paramJsonKeyLookup.values.toList.distinct.length != caseClass.params.length) {
+      throw new BsonDerivationError("Duplicate key detected after applying transformation function for case class parameters")
+    }
+
+    if (configuration.useDefaults) {
+      new BsonDecoder[T] {
+        override def apply(bson: BsonValue): Result[T] =
+          caseClass
+            .constructEither { p =>
+              val key: String = paramJsonKeyLookup.getOrElse(
+                p.label,
+                throw new IllegalStateException("Looking up a parameter label should always yield a value. This is a bug")
+              )
+
+              bson match {
+                case doc: BsonDocument =>
+                  val value: BsonValue = doc.get(key)
+
+                  if (value == null || value.isNull) {
+                    p.default.fold(
+                      // Some decoders (in particular, the default Option[T] decoder) do special things when a key is missing,
+                      // so we give them a chance to do their thing here.
+                      p.typeclass.apply(value)
+                    )(x => x.asRight)
+                  } else {
+                    p.typeclass.apply(value)
+                  }
+
+                case other => new Throwable(s"Not a BsonDocument: ${other}").asLeft
+              }
+            }
+            .leftMap(_.head)
+      }
+    } else {
+      new BsonDecoder[T] {
+        override def apply(bsonValue: BsonValue): Result[T] =
+          bsonValue match {
+            case doc: BsonDocument =>
+              caseClass
+                .constructEither(p =>
+                  p.typeclass
+                    .apply(
+                      doc
+                        .get(
+                          paramJsonKeyLookup.getOrElse(
+                            p.label,
+                            throw new IllegalStateException("Looking up a parameter label should always yield a value. This is a bug")
+                          )
+                        )
+                    )
+                )
+                .leftMap(_.head)
+            case other => throw new IllegalStateException(s"""|Not BsonDocument: $other
+                 |Type: ${caseClass.typeInfo.full}""".stripMargin)
+          }
+      }
+    }
+  }
+
+  private[bson] def split[T](
+      sealedTrait: SealedTrait[BsonDecoder, T]
+  )(implicit configuration: Configuration): BsonDecoder[T] = {
+    val constructorLookup: Map[String, SealedTrait.Subtype[BsonDecoder, T, _]] =
+      sealedTrait.subtypes.map(s => configuration.transformConstructorNames(s.typeInfo.short) -> s).toMap
+
+    if (constructorLookup.size != sealedTrait.subtypes.length) {
+      throw new BsonDerivationError("Duplicate key detected after applying transformation function for case class parameters")
+    }
+
+    configuration.discriminator match {
+      case Some(discriminator) => new DiscriminatedDecoder[T](discriminator, constructorLookup)
+      case None                => new NonDiscriminatedDecoder[T](constructorLookup)
+    }
+  }
+
+  private[bson] class NonDiscriminatedDecoder[T](constructorLookup: Map[String, SealedTrait.Subtype[BsonDecoder, T, _]])
+      extends BsonDecoder[T] {
+
+    private val knownSubTypes: String = constructorLookup.keys.toSeq.sorted.mkString(",")
+
+    override def apply(bson: BsonValue): Result[T] =
+      bson match {
+        case doc: BsonDocument if doc.keySet().size === 1 =>
+          val key: String = doc.getFirstKey
+
+          for {
+            theSubtype <- Either.fromOption(
+              constructorLookup.get(key),
+              new Throwable(
+                s"""|Can't decode coproduct type: couldn't find matching subtype.
+                      |JSON: ${bson},
+                      |Key: $key
+                      |
+                      |Known subtypes: $knownSubTypes\n""".stripMargin
+              )
+            )
+
+            result <- theSubtype.typeclass(doc.get(key))
+          } yield result
+
+        case _ =>
+          Left(
+            new Throwable(
+              s"""|Can't decode coproduct type: zero or several keys were found, while coproduct type requires exactly one.
+                    |JSON: ${bson},
+                    |Keys: $${c.keys.map(_.mkString(","))}
+                    |Known subtypes: $knownSubTypes\n""".stripMargin
+            )
+          )
+      }
+  }
+
+  private[bson] class DiscriminatedDecoder[T](discriminator: String, constructorLookup: Map[String, SealedTrait.Subtype[BsonDecoder, T, _]])
+      extends BsonDecoder[T] {
+
+    val knownSubTypes: String = constructorLookup.keys.toSeq.sorted.mkString(",")
+
+    override def apply(bson: BsonValue): Result[T] =
+      bson match {
+        case doc: BsonDocument =>
+          Either.catchNonFatal(doc.getString(discriminator)) match {
+            case Left(_) =>
+              Left(new Throwable(s"""|Can't decode coproduct type: couldn't find discriminator or is not of type String.
+                      |discriminator key: discriminator""".stripMargin))
+
+            case Right(ctorName) =>
+              constructorLookup.get(ctorName.toString) match {
+                case Some(subType) => subType.typeclass.apply(doc)
+                case None =>
+                  Left(new Throwable(s"""|Can't decode coproduct type: constructor name not found in known constructor names
+                          |BSON: ${doc}
+                          |Allowed discriminators: $knownSubTypes""".stripMargin))
+              }
+          }
+
+        case _ => Left(new Throwable("Not a BsonDocument"))
+      }
+  }
+}

--- a/bson-derivation/src/main/scala-3/mongo4cats/derivation/bson/MagnoliaBsonEncoder.scala
+++ b/bson-derivation/src/main/scala-3/mongo4cats/derivation/bson/MagnoliaBsonEncoder.scala
@@ -1,0 +1,95 @@
+/*
+ * Copyright 2020 Kirill5k
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package mongo4cats.derivation.bson
+
+import magnolia1._
+import mongo4cats.derivation.bson.configured.Configuration
+import org.bson.{BsonDocument, BsonValue}
+
+private[bson] object MagnoliaBsonEncoder {
+
+  private[bson] def join[T](caseClass: CaseClass[BsonEncoder, T])(implicit config: Configuration): BsonEncoder[T] = {
+    val paramJsonKeyLookup =
+      caseClass.params.map { p =>
+        val jsonKeyAnnotation = p.annotations.collectFirst { case ann: BsonKey => ann }
+
+        jsonKeyAnnotation match {
+          case Some(ann) => p.label -> ann.value
+          case None      => p.label -> config.transformMemberNames(p.label)
+        }
+      }.toMap
+
+    if (paramJsonKeyLookup.values.toList.distinct.size != caseClass.params.length) {
+      throw new BsonDerivationError(
+        "Duplicate key detected after applying transformation function for case class parameters"
+      )
+    }
+
+    new BsonEncoder[T] {
+      def apply(a: T): BsonValue = {
+        val bsonDoc = new BsonDocument(caseClass.params.size)
+
+        caseClass.params
+          .map { p =>
+            val label = paramJsonKeyLookup.getOrElse(
+              p.label,
+              throw new IllegalStateException("Looking up a parameter label should always yield a value. This is a bug")
+            )
+            label -> p.typeclass(p.deref(a))
+          }
+          .foreach { case (k, v) => bsonDoc.append(k, v) }
+
+        bsonDoc
+      }
+    }
+  }
+
+  private[bson] def split[T](
+      sealedTrait: SealedTrait[BsonEncoder, T]
+  )(implicit config: Configuration): BsonEncoder[T] = {
+    {
+      val origTypeNames = sealedTrait.subtypes.map(_.typeInfo.short)
+      val transformed   = origTypeNames.map(config.transformConstructorNames).distinct
+      if (transformed.length != origTypeNames.length) {
+        throw new BsonDerivationError(
+          "Duplicate key detected after applying transformation function for " +
+            "sealed trait child classes"
+        )
+      }
+    }
+
+    new BsonEncoder[T] {
+      def apply(a: T): BsonValue =
+        sealedTrait.choose(a) { subtype =>
+          val baseJson = subtype.typeclass(subtype.cast(a))
+          val constructorName = config
+            .transformConstructorNames(subtype.typeInfo.short)
+          config.discriminator match {
+            case Some(discriminator) =>
+              // Note: Here we handle the edge case where a subtype of a sealed trait has a custom encoder which does not encode
+              // encode into a JSON object and thus we cannot insert the discriminator key. In this case we fallback
+              // to the non-discriminator case for this subtype. This is same as the behavior of circe-generic-extras
+              baseJson match {
+                case bsonDoc: BsonDocument => bsonDoc.clone().append(discriminator, org.bson.Document.parse(constructorName).toBsonDocument)
+                case _                     => new BsonDocument(constructorName, baseJson)
+              }
+            case None => new BsonDocument(constructorName, baseJson)
+          }
+        }
+    }
+  }
+}

--- a/bson-derivation/src/main/scala-3/mongo4cats/derivation/bson/ScalaVersionDependentBsonDecoders.scala
+++ b/bson-derivation/src/main/scala-3/mongo4cats/derivation/bson/ScalaVersionDependentBsonDecoders.scala
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2020 Kirill5k
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package mongo4cats.derivation.bson
+
+import cats.syntax.all._
+import mongo4cats.derivation.bson.BsonDecoder.instance
+import org.bson.BsonArray
+
+import scala.jdk.CollectionConverters._
+import java.time.Instant
+import scala.collection.Factory
+import scala.util.Try
+
+trait ScalaVersionDependentBsonDecoders {
+
+  implicit def iterableBsonDecoder[L[_], A](implicit decA: BsonDecoder[A], factory: Factory[A, L[A]]): BsonDecoder[L[A]] =
+    instance {
+      case vs: BsonArray => vs.getValues.asScala.toList.traverse(decA(_)).map(_.to(factory))
+      case other         => new Throwable(s"Not a Iterable: ${other}").asLeft
+    }
+
+}

--- a/bson-derivation/src/main/scala-3/mongo4cats/derivation/bson/ScalaVersionDependentBsonEncoders.scala
+++ b/bson-derivation/src/main/scala-3/mongo4cats/derivation/bson/ScalaVersionDependentBsonEncoders.scala
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2020 Kirill5k
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package mongo4cats.derivation.bson
+
+import cats.syntax.all._
+import mongo4cats.derivation.bson.BsonEncoder.instance
+import org.bson.{BsonArray, BsonValue}
+
+import scala.jdk.CollectionConverters._
+import java.time.Instant
+import scala.collection.Iterable
+import scala.util.Try
+
+trait ScalaVersionDependentBsonEncoders {
+
+  implicit final def encodeIterable[L[_] <: Iterable[_], A](implicit encA: BsonEncoder[A]): BsonEncoder[L[A]] =
+    instance {
+      case asIt: Iterable[A] @unchecked =>
+        val arrayList = new java.util.ArrayList[BsonValue](Math.max(0, asIt.knownSize))
+        asIt.foreach(a => arrayList.add(encA(a)))
+        new BsonArray(arrayList)
+      case _ => throw new Throwable("Not an Iterable")
+    }
+}

--- a/bson-derivation/src/main/scala-3/mongo4cats/derivation/bson/configured/decoder/auto.scala
+++ b/bson-derivation/src/main/scala-3/mongo4cats/derivation/bson/configured/decoder/auto.scala
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2020 Kirill5k
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package mongo4cats.derivation.bson.configured.decoder
+
+import io.circe.Decoder
+import mongo4cats.derivation.bson.{BsonDecoder, MagnoliaBsonDecoder}
+import mongo4cats.derivation.bson.configured.Configuration
+import magnolia1.{CaseClass, SealedTrait}
+
+object auto {
+
+  type Typeclass[T] = BsonDecoder[T]
+
+  def join[T](caseClass: CaseClass[Typeclass, T])(implicit configuration: Configuration): Typeclass[T] =
+    MagnoliaBsonDecoder.join(caseClass)
+
+  def split[T](sealedTrait: SealedTrait[Typeclass, T])(implicit configuration: Configuration): Typeclass[T] =
+    MagnoliaBsonDecoder.split(sealedTrait)
+
+  // given  magnoliaConfiguredDecoder[T]: Typeclass[T] = BsonDecoder.derived
+}

--- a/bson-derivation/src/main/scala-3/mongo4cats/derivation/bson/configured/decoder/semiauto.scala
+++ b/bson-derivation/src/main/scala-3/mongo4cats/derivation/bson/configured/decoder/semiauto.scala
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2020 Kirill5k
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package mongo4cats.derivation.bson.configured.decoder
+
+import io.circe.Decoder
+import mongo4cats.derivation.bson.{BsonDecoder, MagnoliaBsonDecoder}
+import mongo4cats.derivation.bson.configured.Configuration
+import magnolia1.{CaseClass, SealedTrait}
+
+object semiauto {
+
+  type Typeclass[T] = BsonDecoder[T]
+
+  def join[T](caseClass: CaseClass[Typeclass, T])(implicit configuration: Configuration): Typeclass[T] =
+    MagnoliaBsonDecoder.join(caseClass)
+
+  def split[T](sealedTrait: SealedTrait[Typeclass, T])(implicit configuration: Configuration): Typeclass[T] =
+    MagnoliaBsonDecoder.split(sealedTrait)
+
+  // def magnoliaConfiguredDecoder[T]: Typeclass[T] = BsonDecoder.derived
+}

--- a/bson-derivation/src/main/scala-3/mongo4cats/derivation/bson/configured/encoder/auto.scala
+++ b/bson-derivation/src/main/scala-3/mongo4cats/derivation/bson/configured/encoder/auto.scala
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2020 Kirill5k
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package mongo4cats.derivation.bson.configured.encoder
+
+import io.circe.Encoder
+import mongo4cats.derivation.bson.{BsonEncoder, MagnoliaBsonEncoder}
+import mongo4cats.derivation.bson.configured.Configuration
+import magnolia1.{CaseClass, SealedTrait}
+
+object auto {
+
+  type Typeclass[T] = BsonEncoder[T]
+
+  def join[T](caseClass: CaseClass[Typeclass, T])(implicit configuration: Configuration): Typeclass[T] =
+    MagnoliaBsonEncoder.join(caseClass)
+
+  def split[T](sealedTrait: SealedTrait[Typeclass, T])(implicit configuration: Configuration): Typeclass[T] =
+    MagnoliaBsonEncoder.split(sealedTrait)
+
+  // given magnoliaConfiguredEncoder[T]: Typeclass[T] = BsonEncoder.derived
+}

--- a/bson-derivation/src/main/scala-3/mongo4cats/derivation/bson/configured/encoder/semiauto.scala
+++ b/bson-derivation/src/main/scala-3/mongo4cats/derivation/bson/configured/encoder/semiauto.scala
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2020 Kirill5k
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package mongo4cats.derivation.bson.configured.encoder
+
+import io.circe.Encoder
+import mongo4cats.derivation.bson.{BsonEncoder, MagnoliaBsonEncoder}
+import mongo4cats.derivation.bson.configured.Configuration
+import magnolia1.{CaseClass, SealedTrait}
+
+object semiauto {
+
+  type Typeclass[T] = BsonEncoder[T]
+
+  def join[T](caseClass: CaseClass[Typeclass, T])(implicit configuration: Configuration): Typeclass[T] =
+    MagnoliaBsonEncoder.join(caseClass)
+
+  def split[T](sealedTrait: SealedTrait[Typeclass, T])(implicit configuration: Configuration): Typeclass[T] =
+    MagnoliaBsonEncoder.split(sealedTrait)
+
+  // def magnoliaConfiguredEncoder[T]: Typeclass[T] = BsonEncoder.derived
+}

--- a/bson-derivation/src/main/scala-3/mongo4cats/derivation/bson/derivation/decoder/auto.scala
+++ b/bson-derivation/src/main/scala-3/mongo4cats/derivation/bson/derivation/decoder/auto.scala
@@ -14,8 +14,18 @@
  * limitations under the License.
  */
 
-package mongo4cats
+package mongo4cats.derivation.bson.derivation.decoder
 
-import scala.collection.convert.AsJavaConverters
+import mongo4cats.derivation.bson.{BsonDecoder, MagnoliaBsonDecoder}
+import mongo4cats.derivation.bson.configured.Configuration
+import magnolia1.*
 
-trait AsJava extends AsJavaConverters
+object auto extends AutoDerivation[BsonDecoder] {
+
+  def join[T](caseClass: CaseClass[Typeclass, T]): Typeclass[T] =
+    MagnoliaBsonDecoder.join(caseClass)(Configuration.default)
+
+  def split[T](sealedTrait: SealedTrait[Typeclass, T]): Typeclass[T] =
+    MagnoliaBsonDecoder.split(sealedTrait)(Configuration.default)
+
+}

--- a/bson-derivation/src/main/scala-3/mongo4cats/derivation/bson/derivation/decoder/semiauto.scala
+++ b/bson-derivation/src/main/scala-3/mongo4cats/derivation/bson/derivation/decoder/semiauto.scala
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2020 Kirill5k
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package mongo4cats.derivation.bson.derivation.decoder
+
+import io.circe.Decoder
+import mongo4cats.derivation.bson.{BsonDecoder, MagnoliaBsonDecoder}
+import mongo4cats.derivation.bson.configured.Configuration
+import magnolia1.{CaseClass, SealedTrait}
+
+object semiauto {
+
+  type Typeclass[T] = BsonDecoder[T]
+
+  def join[T](caseClass: CaseClass[Typeclass, T]): Typeclass[T] =
+    MagnoliaBsonDecoder.join(caseClass)(Configuration.default)
+
+  def split[T](sealedTrait: SealedTrait[Typeclass, T]): Typeclass[T] =
+    MagnoliaBsonDecoder.split(sealedTrait)(Configuration.default)
+
+  // def magnoliaBsonDecoder[T]: Typeclass[T] = BsonDecoder.derived
+}

--- a/bson-derivation/src/main/scala-3/mongo4cats/derivation/bson/derivation/encoder/auto.scala
+++ b/bson-derivation/src/main/scala-3/mongo4cats/derivation/bson/derivation/encoder/auto.scala
@@ -14,8 +14,18 @@
  * limitations under the License.
  */
 
-package mongo4cats
+package mongo4cats.derivation.bson.derivation.encoder
 
-import scala.collection.convert.AsJavaConverters
+import mongo4cats.derivation.bson.{BsonEncoder, MagnoliaBsonEncoder}
+import mongo4cats.derivation.bson.configured.Configuration
+import magnolia1.*
 
-trait AsJava extends AsJavaConverters
+object auto extends AutoDerivation[BsonEncoder] {
+
+  def join[T](caseClass: CaseClass[Typeclass, T]): Typeclass[T] =
+    MagnoliaBsonEncoder.join(caseClass)(Configuration.default)
+
+  def split[T](sealedTrait: SealedTrait[Typeclass, T]): Typeclass[T] =
+    MagnoliaBsonEncoder.split(sealedTrait)(Configuration.default)
+
+}

--- a/bson-derivation/src/main/scala-3/mongo4cats/derivation/bson/derivation/encoder/semiauto.scala
+++ b/bson-derivation/src/main/scala-3/mongo4cats/derivation/bson/derivation/encoder/semiauto.scala
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2020 Kirill5k
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package mongo4cats.derivation.bson.derivation.encoder
+
+import mongo4cats.derivation.bson.{BsonEncoder, MagnoliaBsonEncoder}
+import mongo4cats.derivation.bson.configured.Configuration
+import magnolia1.{CaseClass, SealedTrait}
+
+object semiauto {
+
+  type Typeclass[T] = BsonEncoder[T]
+
+  def join[T](caseClass: CaseClass[Typeclass, T]): Typeclass[T] =
+    MagnoliaBsonEncoder.join(caseClass)(Configuration.default)
+
+  def split[T](sealedTrait: SealedTrait[Typeclass, T]): Typeclass[T] =
+    MagnoliaBsonEncoder.split(sealedTrait)(Configuration.default)
+
+  // def magnoliaBsonEncoder[T]: Typeclass[T] = BsonEncoder.derived
+}

--- a/bson-derivation/src/main/scala/mongo4cats/derivation/bson/AllBsonDecoders.scala
+++ b/bson-derivation/src/main/scala/mongo4cats/derivation/bson/AllBsonDecoders.scala
@@ -1,0 +1,110 @@
+/*
+ * Copyright 2020 Kirill5k
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package mongo4cats.derivation.bson
+
+import cats.syntax.all._
+import mongo4cats.derivation.bson.BsonDecoder.instance
+import org.bson._
+
+import java.time.Instant
+import java.util.UUID
+
+trait AllBsonDecoders extends ScalaVersionDependentBsonDecoders {
+
+  implicit val byteBsonDecoder: BsonDecoder[Byte] =
+    instance {
+      case i: BsonInt32 => i.intValue().toByte.asRight
+      case other        => new Throwable(s"Not a Byte: ${other}").asLeft
+    }
+
+  implicit val shortBsonDecoder: BsonDecoder[Short] =
+    instance {
+      case i: BsonInt32 => i.intValue().toShort.asRight
+      case other        => new Throwable(s"Not a Short: ${other}").asLeft
+    }
+
+  implicit val intBsonDecoder: BsonDecoder[Int] =
+    instance {
+      case i: BsonInt32 => i.intValue().asRight
+      case other        => new Throwable(s"Not an Int: ${other}").asLeft
+    }
+
+  implicit val longBsonDecoder: BsonDecoder[Long] =
+    instance {
+      case i: BsonInt64 => i.longValue().asRight
+      case other        => new Throwable(s"Not a Long: ${other}").asLeft
+    }
+
+  implicit val stringBsonDecoder: BsonDecoder[String] =
+    instance {
+      case s: BsonString => s.getValue.asRight
+      case other         => new Throwable(s"Not a String: ${other}").asLeft
+    }
+
+  implicit val instantBsonDecoder: BsonDecoder[Instant] =
+    instance {
+      case s: BsonDocument =>
+        s.get("$date") match {
+          case s: BsonString => Instant.parse(s.getValue).asRight
+          case other         => new Throwable(s"Not a Instant: ${other}").asLeft
+        }
+      case other => new Throwable(s"Not a Instant: ${other}").asLeft
+    }
+
+  implicit val decodeBsonObjectId: BsonDecoder[org.bson.types.ObjectId] =
+    instance {
+      case v: BsonObjectId => v.getValue.asRight
+      case other           => new Throwable(s"Not a ObjectId: ${other}").asLeft
+    }
+
+  implicit def optionBsonDecoder[A](implicit decA: BsonDecoder[A]): BsonDecoder[Option[A]] =
+    instance(a =>
+      if (a == null || a.isNull) none.asRight
+      else decA(a).map(_.some)
+    )
+
+  implicit def tuple2BsonDecoder[A, B](implicit decA: BsonDecoder[A], decB: BsonDecoder[B]): BsonDecoder[(A, B)] =
+    BsonDecoder.instance {
+      case arr: BsonArray if arr.size() == 2 => (decA(arr.get(0)), decB(arr.get(1))).tupled
+      case arr: BsonArray                    => new Throwable(s"Not an array of size 2: ${arr}").asLeft
+      case other                             => new Throwable(s"Not an array: ${other}").asLeft
+    }
+
+  implicit val uuidBsonDecoder: BsonDecoder[UUID] =
+    instance {
+      case s: BsonString => Either.catchNonFatal(UUID.fromString(s.getValue))
+      case other         => new Throwable(s"Not an UUID: ${other}").asLeft
+    }
+
+  implicit def mapBsonDecoder[K, V](implicit decK: KeyBsonDecoder[K], decV: BsonDecoder[V]): BsonDecoder[Map[K, V]] =
+    instance {
+      case doc: BsonDocument =>
+        val mapBuilder = scala.collection.mutable.LinkedHashMap[K, V]()
+
+        doc
+          .entrySet()
+          .forEach { entry =>
+            mapBuilder += (decK(entry.getKey).get -> decV(entry.getValue).toOption.get)
+            ()
+          }
+        mapBuilder.toMap.asRight
+
+      case other => new Throwable(s"Not a Document: ${other}").asLeft
+    }
+}
+
+object AllBsonDecoders extends AllBsonDecoders

--- a/bson-derivation/src/main/scala/mongo4cats/derivation/bson/AllBsonEncoders.scala
+++ b/bson-derivation/src/main/scala/mongo4cats/derivation/bson/AllBsonEncoders.scala
@@ -14,8 +14,10 @@
  * limitations under the License.
  */
 
-package mongo4cats
+package mongo4cats.derivation.bson
 
-import scala.collection.convert.AsJavaConverters
+import mongo4cats.AsJava
 
-trait AsJava extends AsJavaConverters
+trait AllBsonEncoders extends ScalaVersionDependentBsonEncoders with MidBsonEncoder with AsJava
+
+object AllBsonEncoders extends AllBsonEncoders

--- a/bson-derivation/src/main/scala/mongo4cats/derivation/bson/BsonDecoder.scala
+++ b/bson-derivation/src/main/scala/mongo4cats/derivation/bson/BsonDecoder.scala
@@ -14,8 +14,22 @@
  * limitations under the License.
  */
 
-package mongo4cats
+package mongo4cats.derivation.bson
 
-import scala.collection.convert.AsJavaConverters
+import org.bson.BsonValue
 
-trait AsJava extends AsJavaConverters
+/** A type class that provides a way to produce a value of type `A` from a [[org.bson.BsonValue]] value. */
+trait BsonDecoder[A] {
+
+  /** Decode the given [[org.bson.BsonValue]]. */
+  def apply(bson: BsonValue): BsonDecoder.Result[A]
+}
+
+object BsonDecoder {
+
+  type Result[A] = Either[Throwable, A]
+
+  def apply[A](implicit ev: BsonDecoder[A]): BsonDecoder[A] = ev
+
+  def instance[A](f: BsonValue => Either[Throwable, A]): BsonDecoder[A] = f(_)
+}

--- a/bson-derivation/src/main/scala/mongo4cats/derivation/bson/BsonDerivationError.scala
+++ b/bson-derivation/src/main/scala/mongo4cats/derivation/bson/BsonDerivationError.scala
@@ -14,8 +14,6 @@
  * limitations under the License.
  */
 
-package mongo4cats
+package mongo4cats.derivation.bson
 
-import scala.collection.convert.AsJavaConverters
-
-trait AsJava extends AsJavaConverters
+class BsonDerivationError(message: String) extends Exception(message)

--- a/bson-derivation/src/main/scala/mongo4cats/derivation/bson/BsonEncoder.scala
+++ b/bson-derivation/src/main/scala/mongo4cats/derivation/bson/BsonEncoder.scala
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2020 Kirill5k
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package mongo4cats.derivation.bson
+
+import mongo4cats.AsJava
+import org.bson.BsonValue
+
+/** A type class that provides a conversion from a value of type `A` to a [[BsonValue]] value. */
+trait BsonEncoder[A] extends Serializable with AsJava { self =>
+
+  /** Convert a value to BsonValue. */
+  def apply(a: A): BsonValue
+
+  /** Create a new [[BsonEncoder]] by applying a function to a value of type `B` before encoding as an `A`. */
+  final def contramap[B](f: B => A): BsonEncoder[B] =
+    (a: B) => self(f(a))
+
+  /** Create a new [[BsonEncoder]] by applying a function to the output of this one.
+    */
+  final def mapBsonValue(f: BsonValue => BsonValue): BsonEncoder[A] =
+    (a: A) => f(self(a))
+}
+
+object BsonEncoder {
+
+  def apply[A](implicit ev: BsonEncoder[A]): BsonEncoder[A] = ev
+
+  def instance[A](f: A => BsonValue): BsonEncoder[A] = f(_)
+}

--- a/bson-derivation/src/main/scala/mongo4cats/derivation/bson/BsonKey.scala
+++ b/bson-derivation/src/main/scala/mongo4cats/derivation/bson/BsonKey.scala
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 
-package mongo4cats
+package mongo4cats.derivation.bson
 
-import scala.collection.convert.AsJavaConverters
+import scala.annotation.StaticAnnotation
 
-trait AsJava extends AsJavaConverters
+final case class BsonKey(value: String) extends StaticAnnotation

--- a/bson-derivation/src/main/scala/mongo4cats/derivation/bson/KeyBsonDecoder.scala
+++ b/bson-derivation/src/main/scala/mongo4cats/derivation/bson/KeyBsonDecoder.scala
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2020 Kirill5k
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package mongo4cats.derivation.bson
+
+import cats.syntax.all._
+
+/** A type class that provides a conversion from a string used as a BSON key to a value of type `A`.
+  */
+trait KeyBsonDecoder[A] extends Serializable { self =>
+
+  /** Attempt to convert a String to a value.
+    */
+  def apply(key: String): Option[A]
+
+  /** Construct an instance for type `B` from an instance for type `A`.
+    */
+  final def map[B](f: A => B): KeyBsonDecoder[B] = new KeyBsonDecoder[B] {
+    final def apply(key: String): Option[B] = self(key).map(f)
+  }
+
+  /** Construct an instance for type `B` from an instance for type `A` given a monadic function.
+    */
+  final def flatMap[B](f: A => KeyBsonDecoder[B]): KeyBsonDecoder[B] = new KeyBsonDecoder[B] {
+    final def apply(key: String): Option[B] = self(key).flatMap(a => f(a)(key))
+  }
+}
+
+object KeyBsonDecoder {
+  def apply[A](implicit A: KeyBsonDecoder[A]): KeyBsonDecoder[A] = A
+
+  def instance[A](f: String => Option[A]): KeyBsonDecoder[A] = f(_)
+
+  implicit val decodeKeyString: KeyBsonDecoder[String] =
+    instance(_.some)
+
+}

--- a/bson-derivation/src/main/scala/mongo4cats/derivation/bson/KeyBsonEncoder.scala
+++ b/bson-derivation/src/main/scala/mongo4cats/derivation/bson/KeyBsonEncoder.scala
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2020 Kirill5k
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package mongo4cats.derivation.bson
+
+import cats.Contravariant
+
+import java.util.UUID
+
+/** A type class that provides a conversion from a value of type `A` to a string.
+  *
+  * This type class will be used to create strings for BSON keys when encoding `Map[A, ?]` instances as BSON.
+  *
+  * Note that if more than one value maps to the same string, the resulting BSON object may have fewer fields than the original map.
+  */
+trait KeyBsonEncoder[A] extends Serializable { self =>
+
+  /** Convert a key value to a string. */
+  def apply(key: A): String
+
+  /** Construct an instance for type `B` from an instance for type `A`. */
+  final def contramap[B](f: B => A): KeyBsonEncoder[B] = new KeyBsonEncoder[B] {
+    final def apply(key: B): String = self(f(key))
+  }
+}
+
+object KeyBsonEncoder {
+  @inline def apply[A](implicit A: KeyBsonEncoder[A]): KeyBsonEncoder[A] = A
+
+  def instance[A](f: A => String): KeyBsonEncoder[A] = f(_)
+
+  implicit val encodeKeyString: KeyBsonEncoder[String] = s => s
+  implicit val encodeKeySymbol: KeyBsonEncoder[Symbol] = _.name
+  implicit val encodeKeyUUID: KeyBsonEncoder[UUID]     = _.toString
+  implicit val encodeKeyByte: KeyBsonEncoder[Byte]     = java.lang.Byte.toString(_)
+  implicit val encodeKeyShort: KeyBsonEncoder[Short]   = java.lang.Short.toString(_)
+  implicit val encodeKeyInt: KeyBsonEncoder[Int]       = java.lang.Integer.toString(_)
+  implicit val encodeKeyLong: KeyBsonEncoder[Long]     = java.lang.Long.toString(_)
+
+  implicit val keyEncoderContravariant: Contravariant[KeyBsonEncoder] =
+    new Contravariant[KeyBsonEncoder] {
+      final def contramap[A, B](e: KeyBsonEncoder[A])(f: B => A): KeyBsonEncoder[B] = e.contramap(f)
+    }
+}

--- a/bson-derivation/src/main/scala/mongo4cats/derivation/bson/MidBsonEncoder.scala
+++ b/bson-derivation/src/main/scala/mongo4cats/derivation/bson/MidBsonEncoder.scala
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2020 Kirill5k
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package mongo4cats.derivation.bson
+import mongo4cats.derivation.bson.BsonEncoder.instance
+import org.bson.{BsonArray, BsonDocument, BsonInt32, BsonInt64, BsonObjectId, BsonString, BsonValue}
+
+import java.time.Instant
+import java.util.UUID
+
+trait MidBsonEncoder {
+
+  implicit val stringBsonEncoder: BsonEncoder[String] = instance(new BsonString(_))
+  implicit val byteBsonEncoder: BsonEncoder[Byte]     = instance(byte => new BsonInt32(byte.toInt))
+  implicit val shortBsonEncoder: BsonEncoder[Short]   = instance(short => new BsonInt32(short.toInt))
+  implicit val intBsonEncoder: BsonEncoder[Int]       = instance(new BsonInt32(_))
+  implicit val longBsonEncoder: BsonEncoder[Long]     = instance(new BsonInt64(_))
+
+  implicit val instantBsonEncoder: BsonEncoder[Instant] =
+    instance(instant => new BsonDocument("$date", new BsonString(instant.toString)))
+
+  implicit val encodeBsonObjectId: BsonEncoder[org.bson.types.ObjectId] =
+    instance(new BsonObjectId(_))
+
+  implicit def encodeOption[A](implicit encA: BsonEncoder[A]): BsonEncoder[Option[A]] =
+    instance {
+      case Some(v) => encA(v)
+      case None    => org.bson.BsonNull.VALUE
+    }
+
+  implicit def encodeSeq[L[_] <: Seq[_], A](implicit encA: BsonEncoder[A]): BsonEncoder[L[A]] =
+    instance {
+      case asSeq: Seq[A] @unchecked =>
+        val arrayList = new java.util.ArrayList[BsonValue](asSeq.size)
+        asSeq.foreach(a => arrayList.add(encA(a)))
+        new BsonArray(arrayList)
+      case _ => throw new Throwable("Not a Seq")
+    }
+
+  implicit def tuple2BsonEncoder[A, B](implicit encA: BsonEncoder[A], encB: BsonEncoder[B]): BsonEncoder[(A, B)] =
+    instance { case (a, b) => new BsonArray(java.util.List.of(encA(a), encB(b))) }
+
+  implicit val uuidBsonEncoder: BsonEncoder[UUID] =
+    instance(uuid => new BsonString(uuid.toString))
+
+  implicit def mapBsonEncoder[K, V](implicit encK: KeyBsonEncoder[K], encV: BsonEncoder[V]): BsonEncoder[Map[K, V]] =
+    instance { kvs =>
+      val bsonDocument = new BsonDocument(kvs.size)
+      kvs.foreach { case (k, v) => bsonDocument.append(encK(k), encV(v)) }
+      bsonDocument
+    }
+}

--- a/bson-derivation/src/main/scala/mongo4cats/derivation/bson/configured/Configuration.scala
+++ b/bson-derivation/src/main/scala/mongo4cats/derivation/bson/configured/Configuration.scala
@@ -1,0 +1,81 @@
+/*
+ * Copyright 2020 Kirill5k
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package mongo4cats.derivation.bson.configured
+
+import java.util.regex.Pattern
+
+/** Configuration allowing customisation of the BSON produced when encoding, or expected when decoding.
+  *
+  * @param transformMemberNames
+  *   Transforms the names of any case class members in the BSON allowing, for example, formatting or case changes. If there are collisions
+  *   in transformed member names, an exception will be thrown during derivation (runtime)
+  * @param useDefaults
+  *   Whether to allow default values as specified for any case-class members.
+  * @param discriminator
+  *   Optional key name that, when given, will be used to store the name of the constructor of an ADT in a nested field with this name. If
+  *   not given, the name is instead stored as a key under which the contents of the ADT are stored as an object. If the discriminator
+  *   conflicts with any of the keys of a case class, an exception will be thrown during derivation (runtime)
+  * @param transformConstructorNames
+  *   Transforms the value of any constructor names in the BSON allowing, for example, formatting or case changes. If there are collisions
+  *   in transformed constructor names, an exception will be thrown during derivation (runtime)
+  */
+final case class Configuration(
+    transformMemberNames: String => String,
+    transformConstructorNames: String => String,
+    useDefaults: Boolean,
+    discriminator: Option[String]
+) {
+  def withSnakeCaseMemberNames: Configuration = copy(
+    transformMemberNames = Configuration.snakeCaseTransformation
+  )
+
+  def withKebabCaseMemberNames: Configuration = copy(
+    transformMemberNames = Configuration.kebabCaseTransformation
+  )
+
+  def withSnakeCaseConstructorNames: Configuration = copy(
+    transformConstructorNames = Configuration.snakeCaseTransformation
+  )
+
+  def withKebabCaseConstructorNames: Configuration = copy(
+    transformConstructorNames = Configuration.kebabCaseTransformation
+  )
+
+  def withDefaults: Configuration                             = copy(useDefaults = true)
+  def withDiscriminator(discriminator: String): Configuration = copy(discriminator = Some(discriminator))
+}
+
+object Configuration {
+
+  val default: Configuration       = Configuration(identity, identity, false, None)
+  private val basePattern: Pattern = Pattern.compile("([A-Z]+)([A-Z][a-z])")
+  private val swapPattern: Pattern = Pattern.compile("([a-z\\d])([A-Z])")
+
+  val snakeCaseTransformation: String => String = s => {
+    val partial = basePattern.matcher(s).replaceAll("$1_$2")
+    swapPattern.matcher(partial).replaceAll("$1_$2").toLowerCase
+  }
+
+  val kebabCaseTransformation: String => String = s => {
+    val partial = basePattern.matcher(s).replaceAll("$1-$2")
+    swapPattern.matcher(partial).replaceAll("$1-$2").toLowerCase
+  }
+}
+
+object defaults {
+  implicit val defaultGenericConfiguration: Configuration = Configuration.default
+}

--- a/bson-derivation/src/main/scala/mongo4cats/derivation/bson/package.scala
+++ b/bson-derivation/src/main/scala/mongo4cats/derivation/bson/package.scala
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2020 Kirill5k
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package mongo4cats.derivation
+
+import org.bson.{BsonArray, BsonDocument, BsonElement, BsonValue}
+
+import java.util
+
+package object bson {
+
+  implicit class BsonValueOps(val bsonValue: BsonValue) extends AnyVal {
+
+    def deepDropNullValues: BsonValue =
+      deepDropNullValuesCreatingBsonValuesOnlyIfModified._1
+
+    /** Drop the entries with a null value if this is an object or array. Return true if the BsonValue had been modified. */
+    private[derivation] def deepDropNullValuesCreatingBsonValuesOnlyIfModified: (BsonValue, Boolean) =
+      bsonValue match {
+        case doc: BsonDocument =>
+          val newElements = new util.ArrayList[BsonElement](doc.size())
+          var modified    = false
+          doc
+            .entrySet()
+            .forEach { entry =>
+              val entryBsonValue: BsonValue = entry.getValue
+              if (entryBsonValue == null || entryBsonValue.isNull) {
+                modified = true
+              } else {
+                val (newValue, valueModified) = entryBsonValue.deepDropNullValuesCreatingBsonValuesOnlyIfModified
+                modified = modified || valueModified
+                newElements.add(new BsonElement(entry.getKey, newValue))
+                ()
+              }
+            }
+
+          (if (modified) new BsonDocument(newElements) else doc, modified)
+
+        case array: BsonArray =>
+          val newValues = new util.ArrayList[BsonValue](array.size())
+          var modified  = false
+          array
+            .forEach { arrayItem =>
+              if (arrayItem == null || arrayItem.isNull) {
+                modified = true
+              } else {
+                val (newValue, valueModified) = arrayItem.deepDropNullValuesCreatingBsonValuesOnlyIfModified
+                modified = modified || valueModified
+                newValues.add(newValue)
+                ()
+              }
+            }
+
+          (if (modified) new BsonArray(newValues) else array, modified)
+
+        case other => (other, false)
+      }
+  }
+
+}

--- a/bson-derivation/src/test/scala-2/mongo4cats/derivation/bson/configured/AutoDerivationTest.scala
+++ b/bson-derivation/src/test/scala-2/mongo4cats/derivation/bson/configured/AutoDerivationTest.scala
@@ -1,0 +1,157 @@
+/*
+ * Copyright 2020 Kirill5k
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package mongo4cats.derivation.bson.configured
+
+import cats.syntax.all._
+import io.circe.generic.extras.auto._
+import io.circe.{Decoder, Json, ParsingFailure}
+import io.circe.syntax._
+import mongo4cats.circe._
+import mongo4cats.derivation.bson.AllBsonEncoders._
+import mongo4cats.derivation.bson.AllBsonDecoders._
+import mongo4cats.derivation.bson.configured.decoder.auto._
+import mongo4cats.derivation.bson.configured.encoder.auto._
+import mongo4cats.derivation.bson.{BsonDecoder, BsonEncoder, BsonValueOps}
+import org.bson.BsonDocument
+import org.scalacheck.ScalacheckShapeless._
+import org.scalacheck._
+import org.scalacheck.cats.implicits._
+import org.scalatest.wordspec.AnyWordSpec
+import org.scalatestplus.scalacheck.ScalaCheckDrivenPropertyChecks
+
+import java.util.UUID
+
+final case class RootTestData(
+    testSealedTraits: List[TestSealedTrait],
+    items: List[ItemTestDatas],
+    rootTuple2: (String, Int)
+)
+
+final case class ItemTestDatas(
+    listItems: List[ItemTestData],
+    setItems: Set[ItemTestData],
+    optionItem: Option[ItemTestData]
+)
+
+final case class ItemTestData(
+    idData: TestData[_root_.cats.Id],
+    listData: TestData[List],
+    setData: TestData[Set],
+    optionData: TestData[Option]
+)
+
+final case class TestData[L[_]](
+    stringL: L[String],
+    byteL: L[Byte],
+    shortL: L[Short],
+    intL: L[Int],
+    longL: L[Long],
+    instantL: L[java.time.Instant]
+)
+
+sealed trait TestSealedTrait
+
+object TestSealedTrait {
+  final case object CObj1 extends TestSealedTrait
+  final case object CObj2 extends TestSealedTrait
+  final case class CC1(
+      objId: org.bson.types.ObjectId,
+      string: String,
+      instant: java.time.Instant,
+      map: Map[String, (Int, java.time.Instant)]
+  ) extends TestSealedTrait
+  final case class CC2(
+      uuid: UUID,
+      int: Option[Int] = 3.some,
+      long: Long
+  ) extends TestSealedTrait
+  final case class CC3(
+      byte: Byte,
+      short: Short,
+      int: Option[Int] = 5.some,
+      tuple2: (Long, Int),
+      tuple2Opt: Option[(String, Int)],
+      tuple2OptWithDefault: Option[(String, Int)] = ("ten", 10).some
+  ) extends TestSealedTrait
+}
+
+class AutoDerivationTest extends AnyWordSpec with ScalaCheckDrivenPropertyChecks {
+
+  implicit val objectIdArb: Arbitrary[org.bson.types.ObjectId] =
+    Arbitrary((Gen.choose(0, 16777215), Gen.choose(0, 16777215)).mapN(new org.bson.types.ObjectId(_, _)))
+
+  implicit val shortStringArb: Arbitrary[String] =
+    Arbitrary(Gen.choose(0, 5).flatMap(Gen.stringOfN(_, Gen.alphaChar)))
+
+  implicit override val generatorDrivenConfig: PropertyCheckConfiguration =
+    PropertyCheckConfiguration(minSuccessful = 2000)
+
+  "Derived direct Encode/Decode ADT to org.bson.BsonValue with same result as using mongo4cats.circe with io.circe.generic.extras.auto" in {
+
+    val transformationGen: Gen[String => String] = Gen.oneOf(
+      Seq(
+        identity[String](_),
+        mongo4cats.derivation.bson.configured.Configuration.kebabCaseTransformation,
+        mongo4cats.derivation.bson.configured.Configuration.snakeCaseTransformation
+      )
+    )
+
+    val bsonConfigurationGen: Gen[mongo4cats.derivation.bson.configured.Configuration] =
+      (
+        transformationGen,
+        transformationGen,
+        Gen.oneOf(false, true)
+        // Gen.option(Gen.stringOfN(5, Gen.alphaLowerChar)) // TODO Fix discriminator.
+      ).mapN(mongo4cats.derivation.bson.configured.Configuration(_, _, _, none))
+
+    forAll(Arbitrary.arbitrary[RootTestData], bsonConfigurationGen, Gen.oneOf(false, true)) {
+      case (testData, bsonConfiguration, dropNulls) =>
+        implicit val bsonConf: mongo4cats.derivation.bson.configured.Configuration = bsonConfiguration
+
+        implicit val circeConf: io.circe.generic.extras.Configuration =
+          io.circe.generic.extras.Configuration(
+            transformMemberNames = bsonConf.transformMemberNames,
+            transformConstructorNames = bsonConf.transformConstructorNames,
+            useDefaults = bsonConf.useDefaults,
+            discriminator = bsonConf.discriminator
+          )
+
+        // --- Encode ---
+        val circeJson: Json       = testData.asJson
+        val circeJsonStr: String  = circeJson.noSpaces
+        val bsonDoc: BsonDocument = BsonEncoder[RootTestData].apply(testData).asInstanceOf[BsonDocument]
+        val bsonStr: String       = bsonDoc.toJson().replace("\": ", "\":").replace(", ", ",")
+        assert(
+          bsonStr == circeJsonStr,
+          s"""|, 1) Json String from Bson != Json String from Circe
+            |Bson: $bsonStr
+            |Json: $circeJsonStr""".stripMargin
+        )
+
+        // --- Decode ---
+        val jsonFromBsonStr: Either[ParsingFailure, Json] = io.circe.parser.parse(bsonStr)
+        assert(jsonFromBsonStr.isRight, ", 2) BsonStr Can't be Circe Json Decoded")
+        assert(jsonFromBsonStr == circeJson.asRight, ", 3) BsonStr Circe Json Decoded != Circe Json Encoded")
+
+        val expected: Decoder.Result[RootTestData] =
+          (if (circeConf.useDefaults || dropNulls) circeJson.deepDropNullValues else circeJson).as[RootTestData]
+        val decodedFromBson: BsonDecoder.Result[RootTestData] =
+          BsonDecoder[RootTestData].apply(if (dropNulls) bsonDoc.deepDropNullValues else bsonDoc)
+        assert(decodedFromBson == expected, ", 4) Bson Decoder != Circe Decoder")
+    }
+  }
+}

--- a/bson-derivation/src/test/scala-3/mongo4cats/derivation/bson/configured/AutoDerivationTest.scala
+++ b/bson-derivation/src/test/scala-3/mongo4cats/derivation/bson/configured/AutoDerivationTest.scala
@@ -1,0 +1,173 @@
+/*
+ * Copyright 2020 Kirill5k
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package mongo4cats.derivation.bson.configured
+
+import cats.syntax.all._
+import io.circe.{Decoder, Json, ParsingFailure}
+import io.circe.generic.auto._
+import io.circe.syntax._
+import mongo4cats.circe._
+import mongo4cats.derivation.bson.AllBsonEncoders._
+import mongo4cats.derivation.bson.AllBsonDecoders._
+import mongo4cats.derivation.bson.derivation.decoder.auto._
+import mongo4cats.derivation.bson.derivation.decoder.auto.autoDerived
+import mongo4cats.derivation.bson.derivation.encoder.auto._
+import mongo4cats.derivation.bson.derivation.encoder.auto.autoDerived
+import mongo4cats.derivation.bson.{BsonDecoder, BsonEncoder, BsonValueOps}
+import mongo4cats.derivation.bson.configured.TestSealedTrait.CObj1
+import mongo4cats.derivation.bson.configured.TestSealedTrait.CObj2
+import mongo4cats.derivation.bson.configured.TestSealedTrait.CC1
+import mongo4cats.derivation.bson.configured.TestSealedTrait.CC2
+import mongo4cats.derivation.bson.configured.TestSealedTrait.CC3
+import org.bson.BsonDocument
+import _root_.org.scalacheck._
+import _root_.org.scalacheck.Gen._
+import _root_.org.scalacheck.Arbitrary._
+import _root_.org.scalacheck.Arbitrary.arbitrary
+import _root_.org.scalacheck.cats.implicits._
+import _root_.org.scalatest.wordspec.AnyWordSpec
+import _root_.org.scalatestplus.scalacheck.ScalaCheckDrivenPropertyChecks
+
+import java.util.UUID
+
+final case class RootTestData(
+    int: Int,
+    string: String,
+    // testSealedTraits: List[TestSealedTrait],
+    // items: List[ItemTestDatas],
+    rootTuple2: (String, Int)
+)
+
+final case class ItemTestDatas(
+    listItems: List[ItemTestData],
+    setItems: Set[ItemTestData],
+    optionItem: Option[ItemTestData]
+)
+
+final case class ItemTestData(
+    idData: TestData[_root_.cats.Id],
+    listData: TestData[List],
+    setData: TestData[Set],
+    optionData: TestData[Option]
+)
+
+final case class TestData[L[_]](
+    stringL: L[String],
+    byteL: L[Byte],
+    shortL: L[Short],
+    intL: L[Int],
+    longL: L[Long],
+    instantL: L[java.time.Instant]
+)
+
+sealed trait TestSealedTrait
+
+object TestSealedTrait {
+  case object CObj1 extends TestSealedTrait
+  case object CObj2 extends TestSealedTrait
+  final case class CC1(
+      objId: org.bson.types.ObjectId,
+      string: String,
+      instant: java.time.Instant
+      // map: Map[String, (Int, java.time.Instant)]
+  ) extends TestSealedTrait
+  final case class CC2(
+      uuid: UUID,
+      int: Option[Int] = 3.some,
+      long: Long
+  ) extends TestSealedTrait
+  final case class CC3(
+      byte: Byte,
+      short: Short,
+      int: Option[Int] = 5.some,
+      tuple2: (Long, Int),
+      tuple2Opt: Option[(String, Int)],
+      tuple2OptWithDefault: Option[(String, Int)] = ("ten", 10).some
+  ) extends TestSealedTrait
+}
+
+class AutoDerivationTest extends AnyWordSpec with ScalaCheckDrivenPropertyChecks {
+
+  implicit val objectIdArb: Arbitrary[org.bson.types.ObjectId] =
+    Arbitrary((Gen.choose(0, 16777215), Gen.choose(0, 16777215)).mapN(new org.bson.types.ObjectId(_, _)))
+
+  implicit val shortStringArb: Arbitrary[String] =
+    Arbitrary(Gen.choose(0, 5).flatMap(Gen.stringOfN(_, Gen.alphaChar)))
+
+  implicit override val generatorDrivenConfig: PropertyCheckConfiguration =
+    PropertyCheckConfiguration(minSuccessful = 2000)
+
+  "Derived direct Encode/Decode ADT to org.bson.BsonValue with same result as using mongo4cats.circe" in {
+
+    val rootTestDataGen: Gen[RootTestData] =
+      (
+        arbitrary[Int],
+        arbitrary[String],
+        // Gen.listOf(
+        //  Gen.oneOf(
+        //    Gen.const(CObj1),
+        //    Gen.const(CObj2),
+        //    (
+        //      arbitrary[org.bson.types.ObjectId],
+        //      arbitrary[String],
+        //      arbitrary[java.time.Instant]
+        //      // arbitrary[Map[String, (Int, java.time.Instant)]]
+        //    ).mapN(CC1.apply),
+        //    (
+        //      arbitrary[UUID],
+        //      Gen.option(arbitrary[Int]),
+        //      arbitrary[Long]
+        //    ).mapN(CC2.apply),
+        //    (
+        //      arbitrary[Byte],
+        //      arbitrary[Short],
+        //      Gen.option(arbitrary[Int]),
+        //      (arbitrary[Long], arbitrary[Int]).tupled,
+        //      Gen.option((arbitrary[String], arbitrary[Int]).tupled),
+        //      Gen.option((arbitrary[String], arbitrary[Int]).tupled)
+        //    ).mapN(CC3.apply)
+        //  )
+        // ),
+        (arbitrary[String], arbitrary[Int]).tupled
+      ).mapN(RootTestData.apply)
+
+    forAll(rootTestDataGen, Gen.oneOf(false, true)) { case (testData, dropNulls) =>
+      // --- Encode ---
+      val circeJson: Json       = testData.asJson
+      val circeJsonStr: String  = circeJson.noSpaces
+      val bsonDoc: BsonDocument = BsonEncoder[RootTestData].apply(testData).asInstanceOf[BsonDocument]
+      val bsonStr: String       = bsonDoc.toJson().replace("\": ", "\":").replace(", ", ",")
+      assert(
+        bsonStr == circeJsonStr,
+        s"""|, 1) Json String from Bson != Json String from Circe
+            |Bson: $bsonStr
+            |Json: $circeJsonStr""".stripMargin
+      )
+
+      // --- Decode ---
+      val jsonFromBsonStr: Either[ParsingFailure, Json] = io.circe.parser.parse(bsonStr)
+      assert(jsonFromBsonStr.isRight, ", 2) BsonStr Can't be Circe Json Decoded")
+      assert(jsonFromBsonStr == circeJson.asRight, ", 3) BsonStr Circe Json Decoded != Circe Json Encoded")
+
+      val expected: Decoder.Result[RootTestData] =
+        (if (dropNulls) circeJson.deepDropNullValues else circeJson).as[RootTestData]
+      val decodedFromBson: BsonDecoder.Result[RootTestData] =
+        BsonDecoder[RootTestData].apply(if (dropNulls) bsonDoc.deepDropNullValues else bsonDoc)
+      assert(decodedFromBson == expected, ", 4) Bson Decoder != Circe Decoder")
+    }
+  }
+}

--- a/build.sbt
+++ b/build.sbt
@@ -3,10 +3,16 @@ import ReleaseTransformations._
 import microsites.CdnDirectives
 import sbtghactions.JavaSpec
 
-val scala212               = "2.12.15"
+val scala212               = "2.12.16"
 val scala213               = "2.13.8"
 val scala3                 = "3.1.1"
 val supportedScalaVersions = List(scala212, scala213, scala3)
+
+def priorTo2_13(scalaVersion: String): Boolean =
+  CrossVersion.partialVersion(scalaVersion) match {
+    case Some((2, minor)) if minor < 13 => true
+    case _                              => false
+  }
 
 ThisBuild / scalaVersion           := scala213
 ThisBuild / organization           := "io.github.kirill5k"
@@ -52,7 +58,8 @@ val commonSettings = Seq(
   crossScalaVersions := supportedScalaVersions,
   Compile / doc / scalacOptions ++= Seq(
     "-no-link-warnings" // Suppresses problems with Scaladoc links
-  )
+  ),
+  scalacOptions ++= (if (priorTo2_13(scalaVersion.value)) Seq("-Ypartial-unification") else Nil)
 )
 
 val `mongo4cats-embedded` = project

--- a/build.sbt
+++ b/build.sbt
@@ -97,6 +97,34 @@ val `mongo4cats-circe` = project
   )
   .enablePlugins(AutomateHeaderPlugin)
 
+val `mongo4cats-bson-derivation` = project
+  .in(file("bson-derivation"))
+  .dependsOn(`mongo4cats-core`, `mongo4cats-embedded` % "test->compile")
+  .settings(commonSettings)
+  .settings(
+    name := "mongo4cats-bson-derivation",
+    libraryDependencies ++= Dependencies.circe ++ Dependencies.test,
+    libraryDependencies ++=
+      Dependencies.scalacheckCats ++
+        (CrossVersion.partialVersion(scalaVersion.value) match {
+          case Some((2, _)) =>
+            Dependencies.circeGenericExtras ++
+              Dependencies.scalacheckShapeless ++
+              Dependencies.magnolia1_2 ++
+              Seq("org.scala-lang" % "scala-reflect" % scalaVersion.value)
+          case _ => Dependencies.magnolia1_3
+        }),
+    test / parallelExecution := false,
+    mimaPreviousArtifacts    := Set(organization.value %% moduleName.value % "0.4.1"),
+    scalacOptions ++=
+      (CrossVersion.partialVersion(scalaVersion.value) match {
+        case Some((3, _)) => Seq("-Yretain-trees") // For Magnolia: https://github.com/softwaremill/magnolia#limitations
+        case _            => Nil
+      })
+  )
+  .dependsOn(`mongo4cats-circe`)
+  .enablePlugins(AutomateHeaderPlugin)
+
 val `mongo4cats-examples` = project
   .in(file("examples"))
   .dependsOn(`mongo4cats-core`, `mongo4cats-circe`, `mongo4cats-embedded`)
@@ -144,5 +172,6 @@ val root = project
     `mongo4cats-core`,
     `mongo4cats-circe`,
     `mongo4cats-examples`,
-    `mongo4cats-embedded`
+    `mongo4cats-embedded`,
+    `mongo4cats-bson-derivation`
   )

--- a/core/src/main/scala-2.12/mongo4cats/AsJava.scala
+++ b/core/src/main/scala-2.12/mongo4cats/AsJava.scala
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2020 Kirill5k
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package mongo4cats
+
+import java.util.{concurrent => juc}
+import java.{lang => jl, util => ju}
+import scala.collection.mutable
+
+trait AsJava extends scala.collection.convert.AsJavaConverters {
+
+  def asJava[A](i: Iterator[A]): ju.Iterator[A]                                       = asJavaIterator(i)
+  def asJava[A](i: Iterable[A]): jl.Iterable[A]                                       = asJavaIterable(i)
+  def asJava[A](b: mutable.Buffer[A]): ju.List[A]                                     = bufferAsJavaList(b)
+  def asJava[A](s: mutable.Seq[A]): ju.List[A]                                        = mutableSeqAsJavaList(s)
+  def asJava[A](s: Seq[A]): ju.List[A]                                                = seqAsJavaList(s)
+  def asJava[A](s: mutable.Set[A]): ju.Set[A]                                         = mutableSetAsJavaSet(s)
+  def asJava[A](s: Set[A]): ju.Set[A]                                                 = setAsJavaSet(s)
+  def asJava[K, V](m: mutable.Map[K, V]): ju.Map[K, V]                                = mutableMapAsJavaMap(m)
+  def asJava[K, V](m: Map[K, V]): ju.Map[K, V]                                        = mapAsJavaMap(m)
+  def asJava[K, V](m: scala.collection.concurrent.Map[K, V]): juc.ConcurrentMap[K, V] = mapAsJavaConcurrentMap(m)
+}

--- a/core/src/main/scala-2.13/mongo4cats/AsJava.scala
+++ b/core/src/main/scala-2.13/mongo4cats/AsJava.scala
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2020 Kirill5k
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package mongo4cats
+
+import scala.collection.convert.AsJavaConverters
+
+trait AsJava extends AsJavaConverters

--- a/core/src/main/scala-3/mongo4cats/AsJava.scala
+++ b/core/src/main/scala-3/mongo4cats/AsJava.scala
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2020 Kirill5k
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package mongo4cats
+
+import scala.collection.convert.AsJavaConverters
+
+trait AsJava extends AsJavaConverters

--- a/core/src/main/scala/mongo4cats/bson.scala
+++ b/core/src/main/scala/mongo4cats/bson.scala
@@ -26,24 +26,32 @@ import org.bson.codecs.configuration.CodecProvider
 
 import java.time.Instant
 import java.util.Date
-import scala.collection.Iterable
-import scala.jdk.CollectionConverters._
+import java.{util => ju}
+import java.util.{Map => JMap, Set => JSet}
+import java.util.Map.{Entry => JEntry}
+import scala.collection.convert.AsJavaConverters
 
 object bson {
 
   type Document = JDocument
-  object Document {
+
+  object Document extends AsJavaConverters {
     val empty: Document = new JDocument()
 
-    def apply[A](entries: Map[String, A]): Document = new JDocument(
-      entries
-        .map {
-          case (k, v: Iterable[_]) => (k, v.asJava)
-          case (k, v)              => (k, v)
-        }
-        .asInstanceOf[Map[String, AnyRef]]
-        .asJava
-    )
+    def apply[A](entries: Map[String, A]): Document =
+      new JDocument(
+        MapOnlyForJDocumentCreation(
+          entries.size,
+          entries
+            .map {
+              case (k, v: Iterable[_]) =>
+                // Create directly `JEntry` (no `Tuple2` then copied to `JEntry`).
+                // No allocation for `scala.collection.convert.AsJavaExtensions.IterableHasAsJava` (which doesn't `extends AnyVal`).
+                JEntryOnlyForJDocumentCreation(k, asJava(v))
+              case (k, v) => JEntryOnlyForJDocumentCreation(k, v) // Create directly `JEntry`.
+            }
+        )
+      )
 
     def apply[A](entries: (String, A)*): Document = apply[A](entries.toMap[String, A])
     def apply[A](key: String, value: A): Document = apply(key -> value)
@@ -98,4 +106,58 @@ object bson {
       */
     def apply(instant: Instant) = new JObjectId(Date.from(instant))
   }
+}
+
+final private case class JEntryOnlyForJDocumentCreation[A](
+    override val getKey: String,
+    override val getValue: A
+) extends JEntry[String, A] {
+
+  // Copied from [[scala.collection.convert.JavaCollectionWrappers.MapWrapper.entrySet]].
+  // It's important that this implementation conform to the contract
+  // specified in the javadocs of java.util.Map.Entry.hashCode
+  // See https://github.com/scala/bug/issues/10663
+  override def hashCode: Int = ??? // Unused for JDocument creation.
+  // (if (getKey == null) 0 else getKey.hashCode()) ^ (if (getValue == null) 0 else getValue.hashCode())
+
+  override def setValue(value: A): A = ??? // Unused for JDocument creation.
+}
+
+final private case class MapOnlyForJDocumentCreation[A](
+    override val size: Int,
+    entries: Iterable[JEntryOnlyForJDocumentCreation[A]]
+) extends JMap[String, A] {
+  self =>
+
+  /** An Optimized version of [[scala.collection.convert.JavaCollectionWrappers.MapWrapper.entrySet]], implement only what is needed by
+    * [[java.util.HashMap#putMapEntries(java.util.Map, boolean)]] (`size` & `entrySet`).
+    *   - No allocations for `prev` var.
+    *   - No allocations when copying `Tuple2` to `JEntry`.
+    */
+  override def entrySet: JSet[JEntry[String, A]] =
+    new ju.AbstractSet[JEntry[String, A]] {
+      override val size: Int = self.size
+
+      override def iterator: ju.Iterator[JEntry[String, A]] = {
+        val scalaIterator: Iterator[JEntryOnlyForJDocumentCreation[A]] = entries.iterator
+
+        new ju.Iterator[JEntry[String, A]] {
+          def hasNext: Boolean          = scalaIterator.hasNext
+          def next(): JEntry[String, A] = scalaIterator.next()
+
+          override def remove(): Unit = ??? // Unused for JDocument creation.
+        }
+      }
+    }
+
+  override def isEmpty: Boolean                           = ??? // Unused for JDocument creation.
+  override def containsKey(key: Any): Boolean             = ??? // Unused for JDocument creation.
+  override def containsValue(value: Any): Boolean         = ??? // Unused for JDocument creation.
+  override def get(key: Any): A                           = ??? // Unused for JDocument creation.
+  override def put(key: String, value: A): A              = ??? // Unused for JDocument creation.
+  override def remove(key: Any): A                        = ??? // Unused for JDocument creation.
+  override def putAll(m: JMap[_ <: String, _ <: A]): Unit = ??? // Unused for JDocument creation.
+  override def clear(): Unit                              = ??? // Unused for JDocument creation.
+  override def keySet(): JSet[String]                     = ??? // Unused for JDocument creation.
+  override def values(): java.util.Collection[A]          = ??? // Unused for JDocument creation.
 }

--- a/core/src/main/scala/mongo4cats/bson.scala
+++ b/core/src/main/scala/mongo4cats/bson.scala
@@ -47,7 +47,7 @@ object bson {
                 // Create directly `JEntry` (no `Tuple2` then copied to `JEntry`).
                 // No allocation for `scala.collection.convert.AsJavaExtensions.IterableHasAsJava` (which doesn't `extends AnyVal`).
                 JEntryOnlyForJDocumentCreation(k, asJava(v))
-              case (k, v) => JEntryOnlyForJDocumentCreation(k, v) // Create directly `JEntry`.
+              case (k, v) => JEntryOnlyForJDocumentCreation(k, v.asInstanceOf[Object]) // Create directly `JEntry`.
             }
         )
       )
@@ -107,10 +107,10 @@ object bson {
   }
 }
 
-final private case class JEntryOnlyForJDocumentCreation[A](
+final private case class JEntryOnlyForJDocumentCreation(
     override val getKey: String,
-    override val getValue: A
-) extends JEntry[String, A] {
+    override val getValue: Object
+) extends JEntry[String, Object] {
 
   // Copied from [[scala.collection.convert.JavaCollectionWrappers.MapWrapper.entrySet]].
   // It's important that this implementation conform to the contract
@@ -119,13 +119,13 @@ final private case class JEntryOnlyForJDocumentCreation[A](
   override def hashCode: Int = ??? // Unused for JDocument creation.
   // (if (getKey == null) 0 else getKey.hashCode()) ^ (if (getValue == null) 0 else getValue.hashCode())
 
-  override def setValue(value: A): A = ??? // Unused for JDocument creation.
+  override def setValue(value: Object): Object = ??? // Unused for JDocument creation.
 }
 
-final private case class MapOnlyForJDocumentCreation[A](
+final private case class MapOnlyForJDocumentCreation(
     override val size: Int,
-    entries: Iterable[JEntryOnlyForJDocumentCreation[A]]
-) extends JMap[String, A] {
+    entries: Iterable[JEntryOnlyForJDocumentCreation]
+) extends JMap[String, Object] {
   self =>
 
   /** An Optimized version of [[scala.collection.convert.JavaCollectionWrappers.MapWrapper.entrySet]], implement only what is needed by
@@ -133,30 +133,30 @@ final private case class MapOnlyForJDocumentCreation[A](
     *   - No allocations for `prev` var.
     *   - No allocations when copying `Tuple2` to `JEntry`.
     */
-  override def entrySet: JSet[JEntry[String, A]] =
-    new ju.AbstractSet[JEntry[String, A]] {
+  override def entrySet: JSet[JEntry[String, Object]] =
+    new ju.AbstractSet[JEntry[String, Object]] {
       override val size: Int = self.size
 
-      override def iterator: ju.Iterator[JEntry[String, A]] = {
-        val scalaIterator: Iterator[JEntryOnlyForJDocumentCreation[A]] = entries.iterator
+      override def iterator: ju.Iterator[JEntry[String, Object]] = {
+        val scalaIterator: Iterator[JEntryOnlyForJDocumentCreation] = entries.iterator
 
-        new ju.Iterator[JEntry[String, A]] {
-          def hasNext: Boolean          = scalaIterator.hasNext
-          def next(): JEntry[String, A] = scalaIterator.next()
+        new ju.Iterator[JEntry[String, Object]] {
+          def hasNext: Boolean               = scalaIterator.hasNext
+          def next(): JEntry[String, Object] = scalaIterator.next()
 
           override def remove(): Unit = ??? // Unused for JDocument creation.
         }
       }
     }
 
-  override def isEmpty: Boolean                           = ??? // Unused for JDocument creation.
-  override def containsKey(key: Any): Boolean             = ??? // Unused for JDocument creation.
-  override def containsValue(value: Any): Boolean         = ??? // Unused for JDocument creation.
-  override def get(key: Any): A                           = ??? // Unused for JDocument creation.
-  override def put(key: String, value: A): A              = ??? // Unused for JDocument creation.
-  override def remove(key: Any): A                        = ??? // Unused for JDocument creation.
-  override def putAll(m: JMap[_ <: String, _ <: A]): Unit = ??? // Unused for JDocument creation.
-  override def clear(): Unit                              = ??? // Unused for JDocument creation.
-  override def keySet(): JSet[String]                     = ??? // Unused for JDocument creation.
-  override def values(): java.util.Collection[A]          = ??? // Unused for JDocument creation.
+  override def isEmpty: Boolean                                = ??? // Unused for JDocument creation.
+  override def containsKey(key: Any): Boolean                  = ??? // Unused for JDocument creation.
+  override def containsValue(value: Any): Boolean              = ??? // Unused for JDocument creation.
+  override def get(key: Any): Object                           = ??? // Unused for JDocument creation.
+  override def put(key: String, value: Object): Object         = ??? // Unused for JDocument creation.
+  override def remove(key: Any): Object                        = ??? // Unused for JDocument creation.
+  override def putAll(m: JMap[_ <: String, _ <: Object]): Unit = ??? // Unused for JDocument creation.
+  override def clear(): Unit                                   = ??? // Unused for JDocument creation.
+  override def keySet(): JSet[String]                          = ??? // Unused for JDocument creation.
+  override def values(): java.util.Collection[Object]          = ??? // Unused for JDocument creation.
 }

--- a/core/src/main/scala/mongo4cats/bson.scala
+++ b/core/src/main/scala/mongo4cats/bson.scala
@@ -29,13 +29,12 @@ import java.util.Date
 import java.{util => ju}
 import java.util.{Map => JMap, Set => JSet}
 import java.util.Map.{Entry => JEntry}
-import scala.collection.convert.AsJavaConverters
 
 object bson {
 
   type Document = JDocument
 
-  object Document extends AsJavaConverters {
+  object Document extends AsJava {
     val empty: Document = new JDocument()
 
     def apply[A](entries: Map[String, A]): Document =

--- a/core/src/main/scala/mongo4cats/client/MongoClient.scala
+++ b/core/src/main/scala/mongo4cats/client/MongoClient.scala
@@ -20,11 +20,10 @@ import cats.effect.{Async, Resource, Sync}
 import cats.syntax.flatMap._
 import com.mongodb.connection.ClusterDescription
 import com.mongodb.reactivestreams.client.{MongoClient => JMongoClient, MongoClients}
+import mongo4cats.AsJava
 import mongo4cats.bson.Document
 import mongo4cats.database.MongoDatabase
 import mongo4cats.helpers._
-
-import scala.collection.convert.AsJavaConverters
 
 abstract class MongoClient[F[_]] {
   def clusterDescription: ClusterDescription
@@ -60,7 +59,7 @@ final private class LiveMongoClient[F[_]](
     underlying.startSession(options).asyncSingle[F].flatMap(ClientSession.make[F])
 }
 
-object MongoClient extends AsJavaConverters {
+object MongoClient extends AsJava {
 
   def fromConnectionString[F[_]: Async](connectionString: String): Resource[F, MongoClient[F]] =
     clientResource[F](MongoClients.create(connectionString))

--- a/core/src/main/scala/mongo4cats/client/MongoClient.scala
+++ b/core/src/main/scala/mongo4cats/client/MongoClient.scala
@@ -24,7 +24,7 @@ import mongo4cats.bson.Document
 import mongo4cats.database.MongoDatabase
 import mongo4cats.helpers._
 
-import scala.jdk.CollectionConverters._
+import scala.collection.convert.AsJavaConverters
 
 abstract class MongoClient[F[_]] {
   def clusterDescription: ClusterDescription
@@ -60,7 +60,7 @@ final private class LiveMongoClient[F[_]](
     underlying.startSession(options).asyncSingle[F].flatMap(ClientSession.make[F])
 }
 
-object MongoClient {
+object MongoClient extends AsJavaConverters {
 
   def fromConnectionString[F[_]: Async](connectionString: String): Resource[F, MongoClient[F]] =
     clientResource[F](MongoClients.create(connectionString))
@@ -69,7 +69,7 @@ object MongoClient {
     create {
       MongoClientSettings.builder
         .applyToClusterSettings { builder =>
-          val _ = builder.hosts(serverAddresses.toList.asJava)
+          val _ = builder.hosts(asJava(serverAddresses.toList))
         }
         .build()
     }

--- a/core/src/main/scala/mongo4cats/collection/MongoCollection.scala
+++ b/core/src/main/scala/mongo4cats/collection/MongoCollection.scala
@@ -23,6 +23,7 @@ import com.mongodb.bulk.BulkWriteResult
 import com.mongodb.client.result._
 import com.mongodb.reactivestreams.client.{MongoCollection => JMongoCollection}
 import com.mongodb.{MongoNamespace, ReadConcern, ReadPreference, WriteConcern}
+import mongo4cats.AsJava
 import mongo4cats.bson.Document
 import mongo4cats.client.ClientSession
 import mongo4cats.codecs.MongoCodecProvider
@@ -33,7 +34,6 @@ import org.bson.codecs.configuration.CodecRegistries.{fromProviders, fromRegistr
 import org.bson.codecs.configuration.CodecRegistry
 import org.bson.conversions.Bson
 
-import scala.collection.convert.AsJavaConverters
 import scala.reflect.ClassTag
 import scala.util.Try
 
@@ -478,7 +478,7 @@ abstract class MongoCollection[F[_], T] {
 
 final private class LiveMongoCollection[F[_]: Async, T: ClassTag](
     val underlying: JMongoCollection[T]
-) extends MongoCollection[F, T] with AsJavaConverters {
+) extends MongoCollection[F, T] with AsJava {
 
   def readPreference: ReadPreference = underlying.getReadPreference
   def withReadPreference(readPreference: ReadPreference): MongoCollection[F, T] =

--- a/core/src/main/scala/mongo4cats/collection/MongoCollection.scala
+++ b/core/src/main/scala/mongo4cats/collection/MongoCollection.scala
@@ -33,7 +33,7 @@ import org.bson.codecs.configuration.CodecRegistries.{fromProviders, fromRegistr
 import org.bson.codecs.configuration.CodecRegistry
 import org.bson.conversions.Bson
 
-import scala.jdk.CollectionConverters._
+import scala.collection.convert.AsJavaConverters
 import scala.reflect.ClassTag
 import scala.util.Try
 
@@ -478,7 +478,7 @@ abstract class MongoCollection[F[_], T] {
 
 final private class LiveMongoCollection[F[_]: Async, T: ClassTag](
     val underlying: JMongoCollection[T]
-) extends MongoCollection[F, T] {
+) extends MongoCollection[F, T] with AsJavaConverters {
 
   def readPreference: ReadPreference = underlying.getReadPreference
   def withReadPreference(readPreference: ReadPreference): MongoCollection[F, T] =
@@ -511,7 +511,7 @@ final private class LiveMongoCollection[F[_]: Async, T: ClassTag](
     new LiveMongoCollection[F, Y](withNewDocumentClass(underlying))
 
   def aggregate[Y: ClassTag](pipeline: Seq[Bson]): AggregateQueryBuilder[F, Y] =
-    AggregateQueryBuilder(withNewDocumentClass[Y](underlying).aggregate(pipeline.asJava), Nil)
+    AggregateQueryBuilder(withNewDocumentClass[Y](underlying).aggregate(asJava(pipeline)), Nil)
 
   def aggregate[Y: ClassTag](pipeline: Aggregate): AggregateQueryBuilder[F, Y] =
     AggregateQueryBuilder(withNewDocumentClass[Y](underlying).aggregate(pipeline.toBson), Nil)
@@ -520,7 +520,7 @@ final private class LiveMongoCollection[F[_]: Async, T: ClassTag](
     AggregateQueryBuilder(withNewDocumentClass[Y](underlying).aggregate(cs.underlying, pipeline.toBson), Nil)
 
   def watch[Y: ClassTag](pipeline: Seq[Bson]): WatchQueryBuilder[F, Y] =
-    WatchQueryBuilder[F, Y](underlying.watch(pipeline.asJava, clazz[Y]), Nil)
+    WatchQueryBuilder[F, Y](underlying.watch(asJava(pipeline), clazz[Y]), Nil)
 
   def watch[Y: ClassTag](pipeline: Aggregate): WatchQueryBuilder[F, Y] =
     WatchQueryBuilder[F, Y](underlying.watch(pipeline.toBson, clazz[Y]), Nil)
@@ -588,7 +588,7 @@ final private class LiveMongoCollection[F[_]: Async, T: ClassTag](
     underlying.updateMany(filter, update, options).asyncSingle[F]
 
   def updateMany(filter: Bson, update: Seq[Bson], options: UpdateOptions): F[UpdateResult] =
-    underlying.updateMany(filter, update.asJava, options).asyncSingle[F]
+    underlying.updateMany(filter, asJava(update), options).asyncSingle[F]
 
   def updateMany(cs: ClientSession[F], filter: Filter, update: Update, options: UpdateOptions): F[UpdateResult] =
     underlying.updateMany(cs.underlying, filter.toBson, update.toBson, options).asyncSingle[F]
@@ -597,7 +597,7 @@ final private class LiveMongoCollection[F[_]: Async, T: ClassTag](
     underlying.updateOne(filter, update, options).asyncSingle[F]
 
   def updateOne(filter: Bson, update: Seq[Bson], options: UpdateOptions): F[UpdateResult] =
-    underlying.updateOne(filter, update.asJava, options).asyncSingle[F]
+    underlying.updateOne(filter, asJava(update), options).asyncSingle[F]
 
   def updateOne(cs: ClientSession[F], filter: Filter, update: Update, options: UpdateOptions): F[UpdateResult] =
     underlying.updateOne(cs.underlying, filter.toBson, update.toBson, options).asyncSingle[F]
@@ -620,19 +620,20 @@ final private class LiveMongoCollection[F[_]: Async, T: ClassTag](
   def insertOne(cs: ClientSession[F], document: T, options: InsertOneOptions): F[InsertOneResult] =
     underlying.insertOne(cs.underlying, document, options).asyncSingle[F]
 
-  def insertMany(docs: Seq[T], options: InsertManyOptions): F[InsertManyResult] = underlying.insertMany(docs.asJava, options).asyncSingle[F]
+  def insertMany(docs: Seq[T], options: InsertManyOptions): F[InsertManyResult] =
+    underlying.insertMany(asJava(docs), options).asyncSingle[F]
   def insertMany(cs: ClientSession[F], docs: Seq[T], options: InsertManyOptions): F[InsertManyResult] =
-    underlying.insertMany(cs.underlying, docs.asJava, options).asyncSingle[F]
+    underlying.insertMany(cs.underlying, asJava(docs), options).asyncSingle[F]
 
   def count(filter: Bson, options: CountOptions): F[Long] = underlying.countDocuments(filter, options).asyncSingle[F].map(_.longValue())
   def count(cs: ClientSession[F], filter: Filter, options: CountOptions): F[Long] =
     underlying.countDocuments(cs.underlying, filter.toBson, options).asyncSingle[F].map(_.longValue())
 
   def bulkWrite[T1 <: T](commands: Seq[WriteCommand[T1]], options: BulkWriteOptions): F[BulkWriteResult] =
-    underlying.bulkWrite(commands.map(_.writeModel).asJava, options).asyncSingle[F]
+    underlying.bulkWrite(asJava(commands.map(_.writeModel)), options).asyncSingle[F]
 
   def bulkWrite[T1 <: T](cs: ClientSession[F], commands: Seq[WriteCommand[T1]], options: BulkWriteOptions): F[BulkWriteResult] =
-    underlying.bulkWrite(cs.underlying, commands.map(_.writeModel).asJava, options).asyncSingle[F]
+    underlying.bulkWrite(cs.underlying, asJava(commands.map(_.writeModel)), options).asyncSingle[F]
 
   def renameCollection(target: MongoNamespace, options: RenameCollectionOptions): F[Unit] =
     underlying.renameCollection(target, options).asyncVoid[F]

--- a/core/src/main/scala/mongo4cats/collection/operations/Accumulator.scala
+++ b/core/src/main/scala/mongo4cats/collection/operations/Accumulator.scala
@@ -20,7 +20,7 @@ import cats.syntax.alternative._
 import cats.syntax.functor._
 import com.mongodb.client.model.{Accumulators, BsonField}
 
-import scala.jdk.CollectionConverters._
+import scala.collection.convert.AsJavaConverters
 
 trait Accumulator {
 
@@ -162,7 +162,7 @@ trait Accumulator {
   private[collection] def toBson: java.util.List[BsonField]
 }
 
-object Accumulator {
+object Accumulator extends AsJavaConverters {
   private val empty: Accumulator = AccumulatorBuilder(Nil)
 
   /** Creates an \$accumulator pipeline stage
@@ -202,9 +202,9 @@ object Accumulator {
       Accumulators.accumulator(
         fieldName,
         initFunction,
-        initArgs.nonEmpty.guard[Option].as(initArgs.asJava).orNull,
+        initArgs.nonEmpty.guard[Option].as(asJava(initArgs)).orNull,
         accumulateFunction,
-        accumulateArgs.nonEmpty.guard[Option].as(accumulateArgs.asJava).orNull,
+        accumulateArgs.nonEmpty.guard[Option].as(asJava(accumulateArgs)).orNull,
         mergeFunction,
         finalizeFunction.orNull,
         lang
@@ -225,7 +225,7 @@ object Accumulator {
 
 final private case class AccumulatorBuilder(
     override val accumulators: List[BsonField]
-) extends Accumulator {
+) extends Accumulator with AsJavaConverters {
 
   def sum[T](fieldName: String, expression: T): Accumulator =
     AccumulatorBuilder(Accumulators.sum(fieldName, expression) :: accumulators)
@@ -260,5 +260,5 @@ final private case class AccumulatorBuilder(
   override def combinedWith(anotherAccumulator: Accumulator): Accumulator =
     AccumulatorBuilder(anotherAccumulator.accumulators ::: accumulators)
 
-  override private[collection] def toBson: java.util.List[BsonField] = accumulators.reverse.asJava
+  override private[collection] def toBson: java.util.List[BsonField] = asJava(accumulators.reverse)
 }

--- a/core/src/main/scala/mongo4cats/collection/operations/Accumulator.scala
+++ b/core/src/main/scala/mongo4cats/collection/operations/Accumulator.scala
@@ -19,8 +19,7 @@ package mongo4cats.collection.operations
 import cats.syntax.alternative._
 import cats.syntax.functor._
 import com.mongodb.client.model.{Accumulators, BsonField}
-
-import scala.collection.convert.AsJavaConverters
+import mongo4cats.AsJava
 
 trait Accumulator {
 
@@ -162,7 +161,7 @@ trait Accumulator {
   private[collection] def toBson: java.util.List[BsonField]
 }
 
-object Accumulator extends AsJavaConverters {
+object Accumulator extends AsJava {
   private val empty: Accumulator = AccumulatorBuilder(Nil)
 
   /** Creates an \$accumulator pipeline stage
@@ -225,7 +224,7 @@ object Accumulator extends AsJavaConverters {
 
 final private case class AccumulatorBuilder(
     override val accumulators: List[BsonField]
-) extends Accumulator with AsJavaConverters {
+) extends Accumulator with AsJava {
 
   def sum[T](fieldName: String, expression: T): Accumulator =
     AccumulatorBuilder(Accumulators.sum(fieldName, expression) :: accumulators)

--- a/core/src/main/scala/mongo4cats/collection/operations/Aggregate.scala
+++ b/core/src/main/scala/mongo4cats/collection/operations/Aggregate.scala
@@ -19,7 +19,7 @@ package mongo4cats.collection.operations
 import com.mongodb.client.model.{Aggregates, BucketAutoOptions, GraphLookupOptions, MergeOptions, UnwindOptions}
 import org.bson.conversions.Bson
 
-import scala.jdk.CollectionConverters._
+import scala.collection.convert.AsJavaConverters
 
 trait Aggregate {
 
@@ -322,7 +322,7 @@ object Aggregate {
 
 final private case class AggregateBuilder(
     override val aggregates: List[Bson]
-) extends Aggregate {
+) extends Aggregate with AsJavaConverters {
 
   def bucketAuto[TExpression](
       groupBy: TExpression,
@@ -384,5 +384,5 @@ final private case class AggregateBuilder(
 
   override def combinedWith(anotherAggregate: Aggregate): Aggregate = AggregateBuilder(anotherAggregate.aggregates ::: aggregates)
 
-  override private[collection] def toBson: java.util.List[Bson] = aggregates.reverse.asJava
+  override private[collection] def toBson: java.util.List[Bson] = asJava(aggregates.reverse)
 }

--- a/core/src/main/scala/mongo4cats/collection/operations/Aggregate.scala
+++ b/core/src/main/scala/mongo4cats/collection/operations/Aggregate.scala
@@ -16,11 +16,15 @@
 
 package mongo4cats.collection.operations
 
-import com.mongodb.client.model.{Aggregates, BucketAutoOptions, GraphLookupOptions, MergeOptions, UnwindOptions}
+import com.mongodb.client.model.{Aggregates, BucketAutoOptions, Facet => JFacet, GraphLookupOptions, MergeOptions, UnwindOptions}
 import mongo4cats.AsJava
 import org.bson.conversions.Bson
 
-trait Aggregate {
+final case class Facet(name: String, pipeline: Aggregate) {
+  private[operations] def asNative: JFacet = new JFacet(name, pipeline.toBson)
+}
+
+trait Aggregate extends AsJava {
 
   /** Creates a \$bucketAuto pipeline stage
     *
@@ -250,6 +254,18 @@ trait Aggregate {
       options: GraphLookupOptions = new GraphLookupOptions()
   ): Aggregate
 
+  /** Creates a facet pipeline stage
+    *
+    * @param facets
+    *   the facets to use
+    * @return
+    *   the \$facets pipeline stage [[https://docs.mongodb.com/manual/reference/operator/aggregation/facet/]]
+    * @since 3.4
+    */
+  def facet(facets: List[Facet]): Aggregate
+
+  def facet(facets: Facet*): Aggregate = facet(facets.toList)
+
   /** Creates a \$unionWith pipeline stage.
     *
     * @param collection
@@ -316,6 +332,8 @@ object Aggregate {
       options: GraphLookupOptions = new GraphLookupOptions()
   ): Aggregate = empty.graphLookup(from, startWith, connectFromField, connectToField, as, options)
 
+  def facet(facets: List[Facet]): Aggregate                         = empty.facet(facets)
+  def facet(facets: Facet*): Aggregate                              = empty.facet(facets.toList)
   def unionWith(collection: String, pipeline: Aggregate): Aggregate = empty.unionWith(collection, pipeline)
 }
 
@@ -377,6 +395,8 @@ final private case class AggregateBuilder(
       as: String,
       options: GraphLookupOptions = new GraphLookupOptions()
   ): Aggregate = AggregateBuilder(Aggregates.graphLookup(from, startWith, connectFromField, connectToField, as, options) :: aggregates)
+
+  def facet(facets: List[Facet]): Aggregate = AggregateBuilder(Aggregates.facet(asJava(facets.map(_.asNative))) :: aggregates)
 
   def unionWith(collection: String, pipeline: Aggregate): Aggregate =
     AggregateBuilder(Aggregates.unionWith(collection, pipeline.toBson) :: aggregates)

--- a/core/src/main/scala/mongo4cats/collection/operations/Aggregate.scala
+++ b/core/src/main/scala/mongo4cats/collection/operations/Aggregate.scala
@@ -17,9 +17,8 @@
 package mongo4cats.collection.operations
 
 import com.mongodb.client.model.{Aggregates, BucketAutoOptions, GraphLookupOptions, MergeOptions, UnwindOptions}
+import mongo4cats.AsJava
 import org.bson.conversions.Bson
-
-import scala.collection.convert.AsJavaConverters
 
 trait Aggregate {
 
@@ -322,7 +321,7 @@ object Aggregate {
 
 final private case class AggregateBuilder(
     override val aggregates: List[Bson]
-) extends Aggregate with AsJavaConverters {
+) extends Aggregate with AsJava {
 
   def bucketAuto[TExpression](
       groupBy: TExpression,

--- a/core/src/main/scala/mongo4cats/collection/operations/Filter.scala
+++ b/core/src/main/scala/mongo4cats/collection/operations/Filter.scala
@@ -21,7 +21,7 @@ import com.mongodb.client.model.{Filters, TextSearchOptions}
 import org.bson.BsonType
 import org.bson.conversions.Bson
 
-import scala.jdk.CollectionConverters._
+import scala.collection.convert.AsJavaConverters
 import scala.util.matching.Regex
 
 trait Filter {
@@ -77,7 +77,7 @@ trait Filter {
   private[operations] def filter: Bson
 }
 
-object Filter {
+object Filter extends AsJavaConverters {
 
   /** A filter that matches all documents.
     *
@@ -192,7 +192,7 @@ object Filter {
     *   the filter
     */
   def in[A](fieldName: String, values: Seq[A]): Filter =
-    FilterBuilder(Filters.in(fieldName, values.asJava))
+    FilterBuilder(Filters.in(fieldName, asJava(values)))
 
   /** Creates a filter that matches all documents where the value of a field does not equal any of the specified values or does not exist.
     *
@@ -204,7 +204,7 @@ object Filter {
     *   the filter
     */
   def nin[A](fieldName: String, values: Seq[A]): Filter =
-    FilterBuilder(Filters.nin(fieldName, values.asJava))
+    FilterBuilder(Filters.nin(fieldName, asJava(values)))
 
   /** Creates a filter that matches all documents that contain the given field.
     *
@@ -331,7 +331,7 @@ object Filter {
     *   the filter
     */
   def all[A](fieldName: String, values: Seq[A]): Filter =
-    FilterBuilder(Filters.all(fieldName, values.asJava))
+    FilterBuilder(Filters.all(fieldName, asJava(values)))
 
   /** Creates a filter that matches all documents containing a field that is an array where at least one member of the array matches the
     * given filter.
@@ -468,7 +468,7 @@ object Filter {
     * @since 3.1
     */
   def geoWithinPolygon(fieldName: String, points: Seq[Seq[Double]]): Filter =
-    FilterBuilder(Filters.geoWithinPolygon(fieldName, points.map(_.map(Double.box).asJava).asJava))
+    FilterBuilder(Filters.geoWithinPolygon(fieldName, asJava(points.map(p => asJava(p.map(Double.box))))))
 
   /** Creates a filter that matches all documents containing a field with grid coordinates data that exist entirely within the specified
     * circle.

--- a/core/src/main/scala/mongo4cats/collection/operations/Filter.scala
+++ b/core/src/main/scala/mongo4cats/collection/operations/Filter.scala
@@ -18,10 +18,10 @@ package mongo4cats.collection.operations
 
 import com.mongodb.client.model.geojson.{Geometry, Point}
 import com.mongodb.client.model.{Filters, TextSearchOptions}
+import mongo4cats.AsJava
 import org.bson.BsonType
 import org.bson.conversions.Bson
 
-import scala.collection.convert.AsJavaConverters
 import scala.util.matching.Regex
 
 trait Filter {
@@ -77,7 +77,7 @@ trait Filter {
   private[operations] def filter: Bson
 }
 
-object Filter extends AsJavaConverters {
+object Filter extends AsJava {
 
   /** A filter that matches all documents.
     *

--- a/core/src/main/scala/mongo4cats/collection/operations/Index.scala
+++ b/core/src/main/scala/mongo4cats/collection/operations/Index.scala
@@ -17,9 +17,8 @@
 package mongo4cats.collection.operations
 
 import com.mongodb.client.model.Indexes
+import mongo4cats.AsJava
 import org.bson.conversions.Bson
-
-import scala.collection.convert.AsJavaConverters
 
 trait Index {
 
@@ -144,7 +143,7 @@ object Index {
 
 final private case class IndexBuilder(
     override val indexes: List[Bson]
-) extends Index with AsJavaConverters {
+) extends Index with AsJava {
 
   override def ascending(fieldName: String): Index         = IndexBuilder(Indexes.ascending(fieldName) :: indexes)
   override def ascending(fieldNames: Seq[String]): Index   = IndexBuilder(Indexes.ascending(asJava(fieldNames)) :: indexes)

--- a/core/src/main/scala/mongo4cats/collection/operations/Index.scala
+++ b/core/src/main/scala/mongo4cats/collection/operations/Index.scala
@@ -19,7 +19,7 @@ package mongo4cats.collection.operations
 import com.mongodb.client.model.Indexes
 import org.bson.conversions.Bson
 
-import scala.jdk.CollectionConverters._
+import scala.collection.convert.AsJavaConverters
 
 trait Index {
 
@@ -144,14 +144,14 @@ object Index {
 
 final private case class IndexBuilder(
     override val indexes: List[Bson]
-) extends Index {
+) extends Index with AsJavaConverters {
 
   override def ascending(fieldName: String): Index         = IndexBuilder(Indexes.ascending(fieldName) :: indexes)
-  override def ascending(fieldNames: Seq[String]): Index   = IndexBuilder(Indexes.ascending(fieldNames.asJava) :: indexes)
+  override def ascending(fieldNames: Seq[String]): Index   = IndexBuilder(Indexes.ascending(asJava(fieldNames)) :: indexes)
   override def descending(fieldName: String): Index        = IndexBuilder(Indexes.descending(fieldName) :: indexes)
-  override def descending(fieldNames: Seq[String]): Index  = IndexBuilder(Indexes.descending(fieldNames.asJava) :: indexes)
+  override def descending(fieldNames: Seq[String]): Index  = IndexBuilder(Indexes.descending(asJava(fieldNames)) :: indexes)
   override def geo2dsphere(fieldName: String): Index       = IndexBuilder(Indexes.geo2dsphere(fieldName) :: indexes)
-  override def geo2dsphere(fieldNames: Seq[String]): Index = IndexBuilder(Indexes.geo2dsphere(fieldNames.asJava) :: indexes)
+  override def geo2dsphere(fieldNames: Seq[String]): Index = IndexBuilder(Indexes.geo2dsphere(asJava(fieldNames)) :: indexes)
   override def geo2d(fieldName: String): Index             = IndexBuilder(Indexes.geo2d(fieldName) :: indexes)
   override def text(fieldName: String): Index              = IndexBuilder(Indexes.text(fieldName) :: indexes)
   override def text: Index                                 = IndexBuilder(Indexes.text() :: indexes)
@@ -159,5 +159,5 @@ final private case class IndexBuilder(
 
   override def combinedWith(anotherIndex: Index): Index = IndexBuilder(anotherIndex.indexes ::: indexes)
 
-  override private[collection] def toBson: Bson = Indexes.compoundIndex(indexes.reverse.asJava)
+  override private[collection] def toBson: Bson = Indexes.compoundIndex(asJava(indexes.reverse))
 }

--- a/core/src/main/scala/mongo4cats/collection/operations/Sort.scala
+++ b/core/src/main/scala/mongo4cats/collection/operations/Sort.scala
@@ -19,7 +19,7 @@ package mongo4cats.collection.operations
 import com.mongodb.client.model.Sorts
 import org.bson.conversions.Bson
 
-import scala.jdk.CollectionConverters._
+import scala.collection.convert.AsJavaConverters
 
 trait Sort {
 
@@ -73,7 +73,7 @@ object Sort {
 
 final private case class SortBuilder(
     override val sorts: List[Bson]
-) extends Sort {
+) extends Sort with AsJavaConverters {
 
   override def asc(fieldNames: String*): Sort         = SortBuilder(Sorts.ascending(fieldNames: _*) :: sorts)
   override def desc(fieldNames: String*): Sort        = SortBuilder(Sorts.descending(fieldNames: _*) :: sorts)
@@ -83,5 +83,5 @@ final private case class SortBuilder(
     SortBuilder(anotherSort.sorts ::: sorts)
 
   override private[collection] def toBson: Bson =
-    Sorts.orderBy(sorts.reverse.asJava)
+    Sorts.orderBy(asJava(sorts.reverse))
 }

--- a/core/src/main/scala/mongo4cats/collection/operations/Sort.scala
+++ b/core/src/main/scala/mongo4cats/collection/operations/Sort.scala
@@ -17,9 +17,8 @@
 package mongo4cats.collection.operations
 
 import com.mongodb.client.model.Sorts
+import mongo4cats.AsJava
 import org.bson.conversions.Bson
-
-import scala.collection.convert.AsJavaConverters
 
 trait Sort {
 
@@ -73,7 +72,7 @@ object Sort {
 
 final private case class SortBuilder(
     override val sorts: List[Bson]
-) extends Sort with AsJavaConverters {
+) extends Sort with AsJava {
 
   override def asc(fieldNames: String*): Sort         = SortBuilder(Sorts.ascending(fieldNames: _*) :: sorts)
   override def desc(fieldNames: String*): Sort        = SortBuilder(Sorts.descending(fieldNames: _*) :: sorts)

--- a/core/src/main/scala/mongo4cats/collection/operations/Update.scala
+++ b/core/src/main/scala/mongo4cats/collection/operations/Update.scala
@@ -19,7 +19,7 @@ package mongo4cats.collection.operations
 import com.mongodb.client.model.{PushOptions, Updates}
 import org.bson.conversions.Bson
 
-import scala.jdk.CollectionConverters._
+import scala.collection.convert.AsJavaConverters
 
 trait Update {
 
@@ -336,7 +336,7 @@ object Update {
 
 final private case class UpdateBuilder(
     override val updates: List[Bson]
-) extends Update {
+) extends Update with AsJavaConverters {
 
   def set[A](fieldName: String, value: A): Update =
     UpdateBuilder(Updates.set(fieldName, value) :: updates)
@@ -375,16 +375,16 @@ final private case class UpdateBuilder(
     UpdateBuilder(Updates.addToSet(fieldName, value) :: updates)
 
   def addEachToSet[A](fieldName: String, values: Seq[A]): Update =
-    UpdateBuilder(Updates.addEachToSet(fieldName, values.asJava) :: updates)
+    UpdateBuilder(Updates.addEachToSet(fieldName, asJava(values)) :: updates)
 
   def push[A](fieldName: String, value: A): Update =
     UpdateBuilder(Updates.push(fieldName, value) :: updates)
 
   def pushEach[A](fieldName: String, values: Seq[A]): Update =
-    UpdateBuilder(Updates.pushEach(fieldName, values.asJava) :: updates)
+    UpdateBuilder(Updates.pushEach(fieldName, asJava(values)) :: updates)
 
   def pushEach[A](fieldName: String, values: Seq[A], options: PushOptions): Update =
-    UpdateBuilder(Updates.pushEach(fieldName, values.asJava, options) :: updates)
+    UpdateBuilder(Updates.pushEach(fieldName, asJava(values), options) :: updates)
 
   def pull[A](fieldName: String, value: A): Update =
     UpdateBuilder(Updates.pull(fieldName, value) :: updates)
@@ -393,7 +393,7 @@ final private case class UpdateBuilder(
     UpdateBuilder(Updates.pullByFilter(filter.toBson) :: updates)
 
   def pullAll[A](fieldName: String, values: Seq[A]): Update =
-    UpdateBuilder(Updates.pullAll(fieldName, values.asJava) :: updates)
+    UpdateBuilder(Updates.pullAll(fieldName, asJava(values)) :: updates)
 
   def popFirst(fieldName: String): Update =
     UpdateBuilder(Updates.popFirst(fieldName) :: updates)
@@ -422,6 +422,6 @@ final private case class UpdateBuilder(
   def combinedWith(anotherUpdate: Update): Update =
     UpdateBuilder(anotherUpdate.updates ::: updates)
 
-  override private[collection] def toBson: Bson = Updates.combine(updates.reverse.asJava)
+  override private[collection] def toBson: Bson = Updates.combine(asJava(updates.reverse))
 
 }

--- a/core/src/main/scala/mongo4cats/collection/operations/Update.scala
+++ b/core/src/main/scala/mongo4cats/collection/operations/Update.scala
@@ -17,9 +17,8 @@
 package mongo4cats.collection.operations
 
 import com.mongodb.client.model.{PushOptions, Updates}
+import mongo4cats.AsJava
 import org.bson.conversions.Bson
-
-import scala.collection.convert.AsJavaConverters
 
 trait Update {
 
@@ -336,7 +335,7 @@ object Update {
 
 final private case class UpdateBuilder(
     override val updates: List[Bson]
-) extends Update with AsJavaConverters {
+) extends Update with AsJava {
 
   def set[A](fieldName: String, value: A): Update =
     UpdateBuilder(Updates.set(fieldName, value) :: updates)

--- a/core/src/test/scala/mongo4cats/collection/MongoCollectionAggregateSpec.scala
+++ b/core/src/test/scala/mongo4cats/collection/MongoCollectionAggregateSpec.scala
@@ -17,7 +17,7 @@
 package mongo4cats.collection
 
 import cats.effect.IO
-import cats.effect.unsafe.implicits.global
+import cats.effect.unsafe.IORuntime
 import mongo4cats.TestData
 import mongo4cats.bson.Document
 import mongo4cats.client.MongoClient
@@ -30,13 +30,10 @@ import org.scalatest.wordspec.AsyncWordSpec
 import scala.concurrent.Future
 
 class MongoCollectionAggregateSpec extends AsyncWordSpec with Matchers with EmbeddedMongo {
-
   override val mongoPort = 12349
 
   "A MongoCollection" when {
-
     "aggregate" should {
-
       "join data from 2 collections" in {
         withEmbeddedMongoDatabase { db =>
           val result = for {
@@ -105,9 +102,32 @@ class MongoCollectionAggregateSpec extends AsyncWordSpec with Matchers with Embe
           } yield res
 
           result.map { expl =>
-            println(expl.toJson)
             expl.getDouble("ok").doubleValue() mustBe 1.0
             expl.getList("stages", classOf[Document]).size() mustBe 4
+          }
+        }
+      }
+
+      "processes multiple aggregation pipelines within a single stage on the same set of input documents" in {
+        withEmbeddedMongoDatabase { db =>
+          val result = for {
+            accs <- db.getCollection("transactions")
+            accumulator = Accumulator
+              .sum("count", 1)
+              .sum("totalAmount", "$amount")
+            res <- accs
+              .aggregate[Document] {
+                Aggregate.facet(
+                  Facet("transactionsByCategory", Aggregate.group("$category", accumulator)),
+                  Facet("transactionsByAccount", Aggregate.group("$account", accumulator))
+                )
+              }
+              .first
+          } yield res
+
+          result.map(_.get).map { res =>
+            res.getList("transactionsByCategory", classOf[Document]) must have size 10
+            res.getList("transactionsByAccount", classOf[Document]) must have size 1
           }
         }
       }
@@ -127,5 +147,5 @@ class MongoCollectionAggregateSpec extends AsyncWordSpec with Matchers with Embe
             res <- test(db)
           } yield res
         }
-    }.unsafeToFuture()
+    }.unsafeToFuture()(IORuntime.global)
 }

--- a/core/src/test/scala/mongo4cats/collection/operations/UpdateSpec.scala
+++ b/core/src/test/scala/mongo4cats/collection/operations/UpdateSpec.scala
@@ -17,14 +17,13 @@
 package mongo4cats.collection.operations
 
 import com.mongodb.client.model.Updates
+import mongo4cats.AsJava
 import org.bson.conversions.Bson
 import org.scalatest.Assertion
 import org.scalatest.matchers.must.Matchers
 import org.scalatest.wordspec.AnyWordSpec
 
-import scala.collection.convert.AsJavaConverters
-
-class UpdateSpec extends AnyWordSpec with Matchers with AsJavaConverters {
+class UpdateSpec extends AnyWordSpec with Matchers with AsJava {
 
   "An Update" should {
     "rename" in {

--- a/core/src/test/scala/mongo4cats/collection/operations/UpdateSpec.scala
+++ b/core/src/test/scala/mongo4cats/collection/operations/UpdateSpec.scala
@@ -22,9 +22,9 @@ import org.scalatest.Assertion
 import org.scalatest.matchers.must.Matchers
 import org.scalatest.wordspec.AnyWordSpec
 
-import scala.jdk.CollectionConverters._
+import scala.collection.convert.AsJavaConverters
 
-class UpdateSpec extends AnyWordSpec with Matchers {
+class UpdateSpec extends AnyWordSpec with Matchers with AsJavaConverters {
 
   "An Update" should {
     "rename" in {
@@ -36,7 +36,7 @@ class UpdateSpec extends AnyWordSpec with Matchers {
     }
 
     "pushEach" in {
-      Update.pushEach("foo", List("foo")) isTheSameAs Updates.pushEach("foo", List("foo").asJava)
+      Update.pushEach("foo", List("foo")) isTheSameAs Updates.pushEach("foo", asJava(List("foo")))
     }
 
     "currentDate" in {
@@ -84,7 +84,7 @@ class UpdateSpec extends AnyWordSpec with Matchers {
     }
 
     "addEachToSet" in {
-      Update.addEachToSet("foo", List(1, 2, 3)) isTheSameAs Updates.addEachToSet("foo", List(1, 2, 3).asJava)
+      Update.addEachToSet("foo", List(1, 2, 3)) isTheSameAs Updates.addEachToSet("foo", asJava(List(1, 2, 3)))
     }
 
     "pull" in {
@@ -92,7 +92,7 @@ class UpdateSpec extends AnyWordSpec with Matchers {
     }
 
     "pullAll" in {
-      Update.pullAll("foo", List(1, 2, 3)) isTheSameAs Updates.pullAll("foo", List(1, 2, 3).asJava)
+      Update.pullAll("foo", List(1, 2, 3)) isTheSameAs Updates.pullAll("foo", asJava(List(1, 2, 3)))
     }
 
     "bitwiseAnd" in {

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -5,14 +5,21 @@ object Dependencies {
     val mongodb     = "4.6.0"
     val fs2         = "3.2.7"
     val scalaCompat = "2.7.0"
-    val circe       = "0.14.1"
+    val circe       = "0.14.2"
 
-    val logback   = "1.2.11"
-    val scalaTest = "3.2.12"
+    val logback             = "1.2.11"
+    val scalaTest           = "3.2.12"
+    val scalaTestScalaCheck = "3.2.13.0"
+    val scalaCheck          = "1.16.0"
 
     val embeddedMongo   = "3.4.5"
     val immutableValue  = "2.9.0"
     val commonsCompress = "1.21"
+
+    val magnolia1_2         = "1.1.2"
+    val magnolia1_3         = "1.1.4"
+    val scalacheckShapeless = "1.3.0"
+    val scalacheckCats      = "0.3.1"
   }
 
   private object Libraries {
@@ -23,16 +30,26 @@ object Dependencies {
     val fs2Core     = "co.fs2"                 %% "fs2-core"                % Versions.fs2
     val scalaCompat = "org.scala-lang.modules" %% "scala-collection-compat" % Versions.scalaCompat
 
-    val circeCore    = "io.circe" %% "circe-core"    % Versions.circe
-    val circeParser  = "io.circe" %% "circe-parser"  % Versions.circe
-    val circeGeneric = "io.circe" %% "circe-generic" % Versions.circe
+    val circeCore          = "io.circe" %% "circe-core"           % Versions.circe
+    val circeParser        = "io.circe" %% "circe-parser"         % Versions.circe
+    val circeGeneric       = "io.circe" %% "circe-generic"        % Versions.circe
+    val circeGenericExtras = "io.circe" %% "circe-generic-extras" % Versions.circe
 
-    val scalaTest = "org.scalatest" %% "scalatest"       % Versions.scalaTest
-    val logback   = "ch.qos.logback" % "logback-classic" % Versions.logback
+    val scalaTest           = "org.scalatest"     %% "scalatest"       % Versions.scalaTest
+    val scalaTestScalaCheck = "org.scalatestplus" %% "scalacheck-1-16" % Versions.scalaTestScalaCheck
+    val scalaCheck          = "org.scalacheck"    %% "scalacheck"      % Versions.scalaCheck
+    val logback             = "ch.qos.logback"     % "logback-classic" % Versions.logback
 
     val embeddedMongo   = "de.flapdoodle.embed" % "de.flapdoodle.embed.mongo" % Versions.embeddedMongo
     val immutableValue  = "org.immutables"      % "value"                     % Versions.immutableValue
     val commonsCompress = "org.apache.commons"  % "commons-compress"          % Versions.commonsCompress
+
+    val magnolia1_2 = "com.softwaremill.magnolia1_2" %% "magnolia" % Versions.magnolia1_2
+    val magnolia1_3 = "com.softwaremill.magnolia1_3" %% "magnolia" % Versions.magnolia1_3
+
+    val scalacheckShapeless = "com.github.alexarchambault" %% "scalacheck-shapeless_1.15" % Versions.scalacheckShapeless
+
+    val scalacheckCats = "io.chrisdavenport" %% "cats-scalacheck" % Versions.scalacheckCats
   }
 
   lazy val core = Seq(
@@ -44,8 +61,10 @@ object Dependencies {
   )
 
   lazy val test = Seq(
-    Libraries.logback   % Test,
-    Libraries.scalaTest % Test
+    Libraries.logback             % Test,
+    Libraries.scalaTest           % Test,
+    Libraries.scalaTestScalaCheck % Test,
+    Libraries.scalaCheck          % Test
   )
 
   lazy val examples = Seq(
@@ -58,10 +77,30 @@ object Dependencies {
     Libraries.circeParser
   )
 
+  lazy val circeGenericExtras = Seq(
+    Libraries.circeGenericExtras
+  )
+
   lazy val embedded = Seq(
     Libraries.fs2Core,
     Libraries.embeddedMongo,
     Libraries.immutableValue,
     Libraries.commonsCompress
+  )
+
+  lazy val magnolia1_2 = Seq(
+    Libraries.magnolia1_2
+  )
+
+  lazy val magnolia1_3 = Seq(
+    Libraries.magnolia1_3
+  )
+
+  lazy val scalacheckShapeless = Seq(
+    Libraries.scalacheckShapeless % Test
+  )
+
+  lazy val scalacheckCats = Seq(
+    Libraries.scalacheckCats
   )
 }

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.6.2
+sbt.version=1.7.1


### PR DESCRIPTION
Add Magnolia generic derivation to `org.bson.BsonValue` for Scala `2.12`, `2.13` and `3` (with minimalist test).

The aim of this work is to encode/decode like `mongo4cats-circe` but directly from ADT to `org.bson.BsonValue`.

Tests using:
```bash
$ sbt "~+mongo4cats-bson-derivation/testQuick"
```

