### PR TITLE
fix connection example

### DIFF
--- a/docs/src/main/mdoc/docs/gettingstarted/connection.md
+++ b/docs/src/main/mdoc/docs/gettingstarted/connection.md
@@ -24,8 +24,8 @@ val clientFromConnString = MongoClient.fromConnectionString[IO]("mongodb://local
 val clientFromServerAddress = MongoClient.fromServerAddress[IO](ServerAddress("localhost", 27017))
 
 // By providing Connection
-val connection = MongoConnection("localhost", 27017, Some(MongoCredential("username", "password")), MongoConnectionType.Srv)
-val clientFromConnection = MongoClient.fromConnection(connection)
+val connection = MongoConnection("localhost", 27017, Some(MongoCredential("username", "password")), MongoConnectionType.Classic)
+val clientFromConnection = MongoClient.fromConnection[IO](connection)
 
 // By providing custom MongoClientSettings object
 val settings = MongoClientSettings.builder().applyConnectionString(ConnectionString("mongodb://localhost:27017")).build()


### PR DESCRIPTION
The documentation example for the connection as is fails to compile 
`java.lang.IllegalArgumentException: Host for when using mongodb+srv protocol can not contain a port`
Changing it to `MongoConnectionType.Classic` resolves this error.

And updates `MongoClient.fromConnection` example to provide [IO] as the `Async[F]`