### PR TITLE
Fix `first` method on aggregate query.

### DIFF
--- a/modules/core/src/main/scala/mongo4cats/collection/Queries.scala
+++ b/modules/core/src/main/scala/mongo4cats/collection/Queries.scala
@@ -91,7 +91,7 @@ private[collection] object Queries {
   ) extends AggregateQueryBuilder[F, T, Stream[F, *]] {
 
     def toCollection: F[Unit]                             = applyQueries().toCollection.asyncVoid[F]
-    def first: F[Option[T]]                               = applyQueries().first().asyncSingle[F].unNone.map(Option.apply)
+    def first: F[Option[T]]                               = applyQueries().first().asyncSingle[F]
     def all: F[Iterable[T]]                               = applyQueries().asyncIterable[F]
     def stream: Stream[F, T]                              = applyQueries().stream[F]
     def boundedStream(capacity: Int): Stream[F, T]        = applyQueries().boundedStream[F](capacity)

--- a/modules/core/src/test/scala/mongo4cats/collection/MongoCollectionAggregateSpec.scala
+++ b/modules/core/src/test/scala/mongo4cats/collection/MongoCollectionAggregateSpec.scala
@@ -151,6 +151,24 @@ class MongoCollectionAggregateSpec extends AsyncWordSpec with Matchers with Embe
           }
         }
       }
+
+      "using first, return none if no result is found" in {
+        withEmbeddedMongoDatabase { db =>
+          val result = for {
+            accs <- db.getCollection("accounts")
+            res <- accs
+              .aggregate[Document](
+                Aggregate
+                  .matchBy(Filter.eq("currency", TestData.LVL))
+              )
+              .first
+          } yield res
+
+          result.map { res =>
+            res mustBe empty
+          }
+        }
+      }
     }
   }
 

--- a/modules/kernel/src/main/scala/mongo4cats/queries/AggregateQueryBuilder.scala
+++ b/modules/kernel/src/main/scala/mongo4cats/queries/AggregateQueryBuilder.scala
@@ -93,11 +93,11 @@ private[mongo4cats] trait AggregateQueries[T, QB] extends QueryBuilder[Aggregate
     */
   def comment(comment: String): QB = withQuery(QueryCommand.Comment(comment))
 
-  /** Add top-level variables to the aggregation. <p> For MongoDB 5.0+, the aggregate command accepts a {@@codelet} option. This option is a
-    * document consisting of zero or more fields representing variables that are accessible to the aggregation pipeline. The key is the name
-    * of the variable and the value is a constant in the aggregate expression language. Each parameter name is then usable to access the
-    * value of the corresponding expression with the "\$\$" syntax within aggregate expression contexts which may require the use of \$expr
-    * or a pipeline. </p>
+  /** Add top-level variables to the aggregation. <p> For MongoDB 5.0+, the aggregate command accepts a {@@@codelet} option. This option is
+    * a document consisting of zero or more fields representing variables that are accessible to the aggregation pipeline. The key is the
+    * name of the variable and the value is a constant in the aggregate expression language. Each parameter name is then usable to access
+    * the value of the corresponding expression with the "\$\$" syntax within aggregate expression contexts which may require the use of
+    * \$expr or a pipeline. </p>
     *
     * @param variables
     *   the variables

--- a/modules/kernel/src/main/scala/mongo4cats/queries/WatchQueryBuilder.scala
+++ b/modules/kernel/src/main/scala/mongo4cats/queries/WatchQueryBuilder.scala
@@ -75,13 +75,13 @@ private[mongo4cats] trait WatchQueries[T, QB] extends QueryBuilder[ChangeStreamP
     */
   def resumeAfter(resumeToken: BsonDocument): QB = withQuery(QueryCommand.ResumeAfter(resumeToken))
 
-  /** Similar to {@@coderesumeAfter} , this option takes a resume token and starts a new change stream returning the first notification
+  /** Similar to {@@@coderesumeAfter} , this option takes a resume token and starts a new change stream returning the first notification
     * after the token.
     *
     * <p>This will allow users to watch collections that have been dropped and recreated or newly renamed collections without missing any
     * notifications.</p>
     *
-    * <p>Note: The server will report an error if both {@@codestartAfter} and {@@coderesumeAfter} are specified.</p>
+    * <p>Note: The server will report an error if both {@@@codestartAfter} and {@@@coderesumeAfter} are specified.</p>
     *
     * @param startAfter
     *   the startAfter resumeToken


### PR DESCRIPTION
Hi,
Currently, if you use `first` method to get the result of an aggregate request and there is no result, it fails instead of returning an Option. So I suggest to remove the call to the `unNone` method.

(Two files were formatted in this PR, idk if it's ok or not.)