### PR TITLE
Use flatMap in jsonToBinaryBase64

### DIFF
--- a/modules/circe/src/main/scala/mongo4cats/circe/CirceJsonMapper.scala
+++ b/modules/circe/src/main/scala/mongo4cats/circe/CirceJsonMapper.scala
@@ -104,7 +104,7 @@ private[circe] object CirceJsonMapper extends JsonMapper[Json] {
     binaryBase64ToJson(Uuid.toBase64(uuid), "04")
 
   def jsonToBinaryBase64(json: Json): Option[String] =
-    json.asObject.get(Tag.binary).flatMap(_.asObject).get("base64").flatMap(_.asString)
+    json.asObject.flatMap(_.apply(Tag.binary)).flatMap(_.asObject).flatMap(_.apply("base64")).flatMap(_.asString)
 
   def jsonToUuid(json: Json): UUID =
     Uuid.fromBase64(jsonToBinaryBase64(json).get)


### PR DESCRIPTION
This helps return better messaging in case of error.

Here are examples of (shorten) stack trace:

before:

```
[error] java.util.NoSuchElementException: None.get
[error]         at scala.None$.get(Option.scala:627)
[error]         at scala.None$.get(Option.scala:626)
[error]         at mongo4cats.circe.CirceJsonMapper$.jsonToBinaryBase64(CirceJsonMapper.scala:107)
[error]         at mongo4cats.circe.MongoJsonCodecs.$init$$
```

after:

```
[error] mongo4cats.errors$MongoJsonParsingException: DecodingFailure at ._id: "eCz830PN" is not a valid binary object
[error]         at mongo4cats.errors$MongoJsonParsingException$.apply(errors.scala:23)
[error]         at mongo4cats.circe.MongoJsonCodecs.mongo4cats$circe$MongoJsonCodecs$$anon$1$$_$get$$anonfun$2$$anonfun$1$$anonfun$1(MongoJsonCodecs.scala:99)
[error]         at scala.util.Either$LeftProjection.map(Either.scala:622)
[error]         at mongo4cats.circe.MongoJsonCodecs$$anon$1.get$$anonfun$2$$anonfun$1(MongoJsonCodecs.scala:99)
[error]         at scala.util.Either.flatMap(Either.scala:360)
[error]         at mongo4cats.circe.MongoJsonCodecs$$anon$1.get$$anonfun$2(MongoJsonCodecs.scala:99)
```