### PR TITLE
Update dependencies

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -2,19 +2,19 @@ import sbt.*
 
 object Dependencies {
   private object Versions {
-    val mongodb            = "5.6.1"
+    val mongodb            = "5.6.2"
     val fs2                = "3.12.2"
     val kindProjector      = "0.13.4"
     val circe              = "0.14.15"
-    val zio                = "2.1.22"
+    val zio                = "2.1.24"
     val zioInteropReactive = "2.0.2"
-    val zioJson            = "0.7.45"
+    val zioJson            = "0.8.0"
 
-    val logback   = "1.5.20"
+    val logback   = "1.5.23"
     val scalaTest = "3.2.19"
 
-    val embeddedMongo   = "4.21.0"
-    val immutableValue  = "2.11.6"
+    val embeddedMongo   = "4.22.0"
+    val immutableValue  = "2.12.0"
     val commonsCompress = "1.28.0"
     val jsr305          = "3.0.2"
   }


### PR DESCRIPTION
Main goal was to update zio-http to `0.8.0` as otherwise it failed on sbt import (w/o customizing evictions) when both mongo4cats-zio and zio-http `0.8.0` were in the build.